### PR TITLE
Ui branch show all annotations

### DIFF
--- a/loinc2hpogui/src/main/java/org/monarchinitiative/loinc2hpo/controller/AnnotateTabController.java
+++ b/loinc2hpogui/src/main/java/org/monarchinitiative/loinc2hpo/controller/AnnotateTabController.java
@@ -5,6 +5,7 @@ package org.monarchinitiative.loinc2hpo.controller;
 import com.github.phenomics.ontolib.formats.hpo.HpoTerm;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
+import com.google.inject.Injector;
 import com.google.inject.Singleton;
 import javafx.beans.property.ReadOnlyStringWrapper;
 import javafx.collections.FXCollections;
@@ -20,6 +21,7 @@ import javafx.scene.input.*;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Circle;
 import javafx.stage.*;
+import javafx.util.Callback;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.monarchinitiative.loinc2hpo.codesystems.Code;
@@ -54,6 +56,10 @@ public class AnnotateTabController {
     private static final Logger logger = LogManager.getLogger();
 
     private Model model=null;
+
+    @Inject
+    private Injector injector;
+
     /** Reference to the third tab. When the user adds a new annotation, we update the table, therefore, we need a reference. */
     @Inject private Loinc2HpoAnnotationsTabController loinc2HpoAnnotationsTabController;
     private ImmutableMap<LoincId,LoincEntry> loincmap=null;
@@ -1273,6 +1279,15 @@ public class AnnotateTabController {
         try {
             FXMLLoader fxmlLoader = new FXMLLoader();
             fxmlLoader.setLocation(getClass().getResource("/fxml/currentAnnotation.fxml"));
+
+            fxmlLoader.setControllerFactory(new Callback<Class<?>, Object>() {
+                @Override
+                public Object call(Class<?> clazz) {
+                    return injector.getInstance(clazz);
+                }
+            });
+//            This sets the same controller factory (Callback) as above using method reference syntax (in single line)
+//            fxmlLoader.setControllerFactory(injector::getInstance);
             root = fxmlLoader.load();
             Scene scene = new Scene(root, 800, 600);
 

--- a/loinc2hpogui/src/main/resources/fxml/annotateTab.fxml
+++ b/loinc2hpogui/src/main/resources/fxml/annotateTab.fxml
@@ -218,6 +218,7 @@
                                  <HBox.margin>
                                     <Insets left="50.0" />
                                  </HBox.margin>
+                                  <fx:include source="currentAnnotation.fxml"/>
                               </Button>
                            </children>
                            <VBox.margin>


### PR DESCRIPTION
Hi Aaron,
I'm not sure I have been able to fully configure the app (in particular to download the LOINC core table file), but I added what I think was missing.

During the processing of `currentAnnotation.fxml` file (after clicking the *All annotations* button) FXMLLoader will ask the controller factory to provide an instance of the class specified in the FXML file that is being processed (tag `fx:controller`, here `org.monarchinitiative.loinc2hpo.controller.CurrentAnnotationController`). FXMLLoader will *not* create the the controller instance by itself.

Method `injector.getInstance(Class<?> clazz)` serves as the controller factory and it should provide an instance of `CurrentAnnotationController` in singleton scope (I have not checked that). The provided instance should then act as a controller for the new `root`.

Could you check if that removes the `NullPointerException`s?
Cheers, Daniel