### PR TITLE
Adjust FXML elements behaviour

### DIFF
--- a/loinc2hpogui/src/main/resources/fxml/annotateTab.fxml
+++ b/loinc2hpogui/src/main/resources/fxml/annotateTab.fxml
@@ -24,7 +24,7 @@
 <?import javafx.scene.shape.Circle?>
 <?import javafx.scene.text.Font?>
 
-<SplitPane dividerPositions="0.6265664160401002" onDragDone="#handleDragDone" onDragOver="#handleDragOver" orientation="VERTICAL" xmlns="http://javafx.com/javafx/8.0.111" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.monarchinitiative.loinc2hpo.controller.AnnotateTabController">
+<SplitPane dividerPositions="0.6265664160401002" onDragDone="#handleDragDone" onDragOver="#handleDragOver" orientation="VERTICAL" xmlns="http://javafx.com/javafx/8.0.121" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.monarchinitiative.loinc2hpo.controller.AnnotateTabController">
   <items>
       <SplitPane dividerPositions="0.6185308848080133">
          <items>
@@ -69,17 +69,17 @@
                               <Insets bottom="10.0" left="20.0" top="20.0" />
                            </HBox.margin>
                         </Label>
-                        <GridPane alignment="CENTER" HBox.hgrow="ALWAYS">
+                        <GridPane alignment="CENTER" HBox.hgrow="SOMETIMES">
                           <columnConstraints>
                             <ColumnConstraints halignment="CENTER" hgrow="SOMETIMES" minWidth="10.0" />
                             <ColumnConstraints halignment="CENTER" hgrow="SOMETIMES" minWidth="10.0" />
                               <ColumnConstraints halignment="CENTER" hgrow="SOMETIMES" minWidth="10.0" />
-                              <ColumnConstraints halignment="CENTER" hgrow="SOMETIMES" minWidth="10.0" />
+                              <ColumnConstraints halignment="CENTER" hgrow="NEVER" minWidth="10.0" />
                           </columnConstraints>
                           <rowConstraints>
-                            <RowConstraints minHeight="30.0" prefHeight="30.0" valignment="CENTER" />
-                            <RowConstraints minHeight="30.0" valignment="CENTER" />
-                              <RowConstraints minHeight="30.0" valignment="CENTER" />
+                            <RowConstraints valignment="CENTER" />
+                            <RowConstraints valignment="CENTER" />
+                              <RowConstraints valignment="CENTER" />
                           </rowConstraints>
                            <children>
                               <Label fx:id="annotationLeftLabel" prefHeight="30.0" text="&lt;Low threshold" textFill="#0e1ccf" GridPane.halignment="CENTER">
@@ -118,7 +118,10 @@
                                     <Insets />
                                  </GridPane.margin>
                               </Button>
-                              <Button mnemonicParsing="false" onAction="#handleAnnotateCodedValue" stylesheets="@../css/loinc2hpo.css" text="+" GridPane.columnIndex="3" />
+                              <Button mnemonicParsing="false" onAction="#handleAnnotateCodedValue" stylesheets="@../css/loinc2hpo.css" text="+" GridPane.columnIndex="3">
+                                 <GridPane.margin>
+                                    <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                                 </GridPane.margin></Button>
                            </children>
                            <HBox.margin>
                               <Insets />
@@ -224,7 +227,7 @@
                         </Button>
                      </children>
                      <VBox.margin>
-                        <Insets left="20.0" top="20.0" />
+                        <Insets left="20.0" top="5.0" />
                      </VBox.margin>
                   </HBox>
                   <TextArea fx:id="annotationNoteField" promptText="Optional: note for annotation" wrapText="true" VBox.vgrow="NEVER">

--- a/loinc2hpogui/src/main/resources/fxml/annotateTab.fxml
+++ b/loinc2hpogui/src/main/resources/fxml/annotateTab.fxml
@@ -24,275 +24,273 @@
 <?import javafx.scene.shape.Circle?>
 <?import javafx.scene.text.Font?>
 
-<AnchorPane fx:id="annotateTab" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="800.0" prefWidth="1200.0" xmlns="http://javafx.com/javafx/9" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.monarchinitiative.loinc2hpo.controller.AnnotateTabController">
-   <children>
-      <SplitPane dividerPositions="0.6265664160401002" onDragDone="#handleDragDone" onDragOver="#handleDragOver" orientation="VERTICAL" prefHeight="800.0" prefWidth="1200.0">
-        <items>
-            <SplitPane dividerPositions="0.6185308848080133">
-               <items>
-                  <VBox prefHeight="96.0" prefWidth="1198.0">
+<SplitPane dividerPositions="0.6265664160401002" onDragDone="#handleDragDone" onDragOver="#handleDragOver" orientation="VERTICAL" xmlns="http://javafx.com/javafx/8.0.111" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.monarchinitiative.loinc2hpo.controller.AnnotateTabController">
+  <items>
+      <SplitPane dividerPositions="0.6185308848080133">
+         <items>
+            <VBox>
+               <children>
+                  <HBox VBox.vgrow="NEVER">
                      <children>
-                        <HBox prefHeight="48.0" prefWidth="200.0">
-                           <children>
-                              <Button fx:id="initLOINCtableButton" mnemonicParsing="false" onAction="#initLOINCtableButton" stylesheets="@../css/loinc2hpo.css" text="Inititialize LOINC Table">
-                                 <HBox.margin>
-                                    <Insets top="10.0" />
-                                 </HBox.margin></Button>
-                              <Button fx:id="IntializeHPOmodelbutton" mnemonicParsing="false" onAction="#initHPOmodelButton" stylesheets="@../css/loinc2hpo.css" text="Initialize HPO model">
-                                 <HBox.margin>
-                                    <Insets left="30.0" top="10.0" />
-                                 </HBox.margin>
-                              </Button>
-                              <Button fx:id="handleLoincFiltering" mnemonicParsing="false" onAction="#handleLoincFiltering" stylesheets="@../css/loinc2hpo.css" text="Filter">
-                                 <HBox.margin>
-                                    <Insets left="30.0" top="10.0" />
-                                 </HBox.margin>
-                              </Button>
-                              <Button fx:id="searchForLOINCIdButton" mnemonicParsing="false" onAction="#search" stylesheets="@../css/loinc2hpo.css" text="Search">
-                                 <HBox.margin>
-                                    <Insets left="30.0" top="10.0" />
-                                 </HBox.margin>
-                              </Button>
-                              <TextField fx:id="loincSearchTextField" onAction="#search" prefHeight="27.0" prefWidth="163.0">
-                                 <HBox.margin>
-                                    <Insets left="20.0" top="10.0" />
-                                 </HBox.margin>
-                              </TextField>
-                           </children>
-                           <VBox.margin>
-                              <Insets left="20.0" top="20.0" />
-                           </VBox.margin>
-                        </HBox>
-                        <HBox prefHeight="48.0" prefWidth="1198.0">
-                           <children>
-                              <HBox prefWidth="1198.0">
-                                 <children>
-                                    <Label stylesheets="@../css/loinc2hpo.css" text="Candidate HPO classes">
-                                       <HBox.margin>
-                                          <Insets bottom="10.0" left="20.0" top="20.0" />
-                                       </HBox.margin>
-                                    </Label>
-                                    <GridPane alignment="TOP_RIGHT" hgap="10.0" prefWidth="450.0" vgap="15.0">
-                                      <columnConstraints>
-                                        <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-                                        <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-                                          <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-                                      </columnConstraints>
-                                      <rowConstraints>
-                                        <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                                        <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                                          <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                                      </rowConstraints>
-                                       <children>
-                                          <Label fx:id="annotationLeftLabel" text="&lt;Low threshold" textFill="#0e1ccf" GridPane.halignment="CENTER" GridPane.valignment="BOTTOM">
-                                             <font>
-                                                <Font name="System Bold" size="13.0" />
-                                             </font>
-                                          </Label>
-                                          <Label fx:id="annotationMiddleLabel" text="intermediant" GridPane.columnIndex="1" GridPane.halignment="CENTER" GridPane.valignment="BOTTOM" />
-                                          <Label fx:id="annotationRightLabel" text="&gt;High threshold" textFill="#c71010" GridPane.columnIndex="2" GridPane.halignment="CENTER" GridPane.valignment="BOTTOM">
-                                             <font>
-                                                <Font name="System Bold" size="13.0" />
-                                             </font>
-                                          </Label>
-                                          <TextField fx:id="annotationTextFieldLeft" onDragDropped="#handleHPOLowAbnormality" onDragEntered="#handleDragEnterLowAbnorm" onDragExited="#handleDragExitLowAbnorm" promptText="phenotype for too low" GridPane.rowIndex="1" />
-                                          <TextField fx:id="annotationTextFieldMiddle" onDragDropped="#handleParentAbnormality" onDragEntered="#handleDragEnterParentAbnorm" onDragExited="#handleDragExitParentAbnorm" promptText="parent phenotype" GridPane.columnIndex="1" GridPane.rowIndex="1" />
-                                          <TextField fx:id="annotationTextFieldRight" onDragDropped="#handleHPOHighAbnormality" onDragEntered="#handleDragEnterHighAbnorm" onDragExited="#handleDragExitHighAbnorm" promptText="phenotype for too high" GridPane.columnIndex="2" GridPane.rowIndex="1" />
-                                          <CheckBox fx:id="inverseChecker" mnemonicParsing="false" selected="true" text="inverse" GridPane.columnIndex="1" GridPane.rowIndex="2">
-                                             <padding>
-                                                <Insets left="9.0" />
-                                             </padding>
-                                          </CheckBox>
-                                          <Button fx:id="modeButton" mnemonicParsing="false" onAction="#annotationModeSwitchButton" stylesheets="@../css/loinc2hpo.css" text="advanced &gt;&gt;&gt;" GridPane.columnIndex="2" GridPane.rowIndex="2">
-                                             <GridPane.margin>
-                                                <Insets bottom="5.0" left="20.0" top="10.0" />
-                                             </GridPane.margin>
-                                          </Button>
-                                       </children>
-                                       <HBox.margin>
-                                          <Insets left="25.0" />
-                                       </HBox.margin>
-                                    </GridPane>
-                                    <Button mnemonicParsing="false" onAction="#handleAnnotateCodedValue" stylesheets="@../css/loinc2hpo.css" text="+">
-                                       <HBox.margin>
-                                          <Insets left="2.0" top="16.0" />
-                                       </HBox.margin>
-                                    </Button>
-                                 </children>
-                                 <HBox.margin>
-                                    <Insets bottom="20.0" top="20.0" />
-                                 </HBox.margin>
-                              </HBox>
-                           </children></HBox>
-                        <HBox prefWidth="200.0">
-                           <children>
-                              <GridPane prefHeight="30.0" prefWidth="735.0">
-                                <columnConstraints>
-                                  <ColumnConstraints hgrow="SOMETIMES" maxWidth="104.0" minWidth="10.0" prefWidth="67.0" />
-                                    <ColumnConstraints hgrow="SOMETIMES" maxWidth="133.0" minWidth="10.0" prefWidth="104.0" />
-                                    <ColumnConstraints hgrow="SOMETIMES" maxWidth="302.0" minWidth="10.0" prefWidth="130.0" />
-                                  <ColumnConstraints hgrow="SOMETIMES" maxWidth="390.0" minWidth="10.0" prefWidth="390.0" />
-                                </columnConstraints>
-                                <rowConstraints>
-                                  <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                                </rowConstraints>
-                                 <children>
-                                    <Label text="Score">
-                                       <GridPane.margin>
-                                          <Insets left="5.0" />
-                                       </GridPane.margin>
-                                    </Label>
-                                    <Label text="ID" GridPane.columnIndex="1">
-                                       <GridPane.margin>
-                                          <Insets left="5.0" />
-                                       </GridPane.margin>
-                                    </Label>
-                                    <Label text="label" GridPane.columnIndex="2">
-                                       <GridPane.margin>
-                                          <Insets left="5.0" />
-                                       </GridPane.margin>
-                                    </Label>
-                                    <Label text="definition" GridPane.columnIndex="3">
-                                       <GridPane.margin>
-                                          <Insets left="5.0" />
-                                       </GridPane.margin>
-                                    </Label>
-                                 </children>
-                              </GridPane>
-                           </children>
-                        </HBox>
-                        <ListView fx:id="hpoListView" onDragDetected="#handleCandidateHPODragged" onMouseClicked="#handleCandidateHPODoubleClick" prefHeight="268.0" prefWidth="737.0">
-                           <contextMenu>
-                              <ContextMenu fx:id="contextMenu">
-                                <items>
-                                    <MenuItem mnemonicParsing="false" text="Review" />
-                                  <MenuItem mnemonicParsing="false" onAction="#suggestNewChildTerm" text="Suggest child term" />
-                                </items>
-                              </ContextMenu>
-                           </contextMenu></ListView>
-                        <HBox prefHeight="0.0" prefWidth="737.0">
-                           <children>
-                              <Button mnemonicParsing="false" onAction="#handleAutoQueryButton" stylesheets="@../css/loinc2hpo.css" text="Auto Query">
-                                 <HBox.margin>
-                                    <Insets bottom="5.0" left="20.0" top="10.0" />
-                                 </HBox.margin>
-                              </Button>
-                              <Button mnemonicParsing="false" onAction="#handleManualQueryButton" stylesheets="@../css/loinc2hpo.css" text="Manual Query">
-                                 <HBox.margin>
-                                    <Insets bottom="5.0" left="20.0" top="10.0" />
-                                 </HBox.margin>
-                              </Button>
-                              <TextField fx:id="userInputForManualQuery" onAction="#handleManualQueryButton" prefHeight="37.0" prefWidth="330.0" promptText="comma seperated keys" stylesheets="@../css/loinc2hpo.css" HBox.hgrow="ALWAYS">
-                                 <HBox.margin>
-                                    <Insets bottom="5.0" left="20.0" top="10.0" />
-                                 </HBox.margin>
-                              </TextField>
-                              <Button fx:id="suggestHPOButton" mnemonicParsing="false" onAction="#suggestNewTerm" prefWidth="100.0" stylesheets="@../css/loinc2hpo.css" text="Suggest New HPO term">
-                                 <HBox.margin>
-                                    <Insets left="5.0" right="5.0" top="10.0" />
-                                 </HBox.margin>
-                              </Button>
-                           </children>
-                           <VBox.margin>
-                              <Insets />
-                           </VBox.margin>
-                        </HBox>
+                        <Button fx:id="initLOINCtableButton" mnemonicParsing="false" onAction="#initLOINCtableButton" stylesheets="@../css/loinc2hpo.css" text="Inititialize LOINC Table">
+                           <HBox.margin>
+                              <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                           </HBox.margin>
+                        </Button>
+                        <Button fx:id="IntializeHPOmodelbutton" mnemonicParsing="false" onAction="#initHPOmodelButton" stylesheets="@../css/loinc2hpo.css" text="Initialize HPO model">
+                           <HBox.margin>
+                              <Insets bottom="5.0" left="10.0" right="5.0" top="5.0" />
+                           </HBox.margin>
+                        </Button>
+                        <Button fx:id="handleLoincFiltering" mnemonicParsing="false" onAction="#handleLoincFiltering" stylesheets="@../css/loinc2hpo.css" text="Filter">
+                           <HBox.margin>
+                              <Insets bottom="5.0" left="30.0" right="5.0" top="5.0" />
+                           </HBox.margin>
+                        </Button>
+                        <Button fx:id="searchForLOINCIdButton" mnemonicParsing="false" onAction="#search" stylesheets="@../css/loinc2hpo.css" text="Search">
+                           <HBox.margin>
+                              <Insets bottom="5.0" left="30.0" right="5.0" top="5.0" />
+                           </HBox.margin>
+                        </Button>
+                        <TextField fx:id="loincSearchTextField" onAction="#search" HBox.hgrow="ALWAYS">
+                           <HBox.margin>
+                              <Insets bottom="5.0" left="20.0" right="5.0" top="5.0" />
+                           </HBox.margin>
+                        </TextField>
                      </children>
-                  </VBox>
-                  <VBox prefHeight="200.0" prefWidth="100.0">
+                     <VBox.margin>
+                        <Insets />
+                     </VBox.margin>
+                  </HBox>
+                  <HBox VBox.vgrow="NEVER">
                      <children>
-                        <HBox prefWidth="200.0" spacing="20.0">
+                        <Label stylesheets="@../css/loinc2hpo.css" text="Candidate HPO classes:">
+                           <HBox.margin>
+                              <Insets bottom="10.0" left="20.0" top="20.0" />
+                           </HBox.margin>
+                        </Label>
+                        <GridPane alignment="CENTER" HBox.hgrow="ALWAYS">
+                          <columnConstraints>
+                            <ColumnConstraints halignment="CENTER" hgrow="SOMETIMES" minWidth="10.0" />
+                            <ColumnConstraints halignment="CENTER" hgrow="SOMETIMES" minWidth="10.0" />
+                              <ColumnConstraints halignment="CENTER" hgrow="SOMETIMES" minWidth="10.0" />
+                              <ColumnConstraints halignment="CENTER" hgrow="SOMETIMES" minWidth="10.0" />
+                          </columnConstraints>
+                          <rowConstraints>
+                            <RowConstraints minHeight="30.0" prefHeight="30.0" valignment="CENTER" />
+                            <RowConstraints minHeight="30.0" valignment="CENTER" />
+                              <RowConstraints minHeight="30.0" valignment="CENTER" />
+                          </rowConstraints>
                            <children>
-                              <Button fx:id="createAnnotationButton" mnemonicParsing="false" onAction="#createLoinc2HpoAnnotation" stylesheets="@../css/loinc2hpo.css" text="Create annotation" />
-                              <CheckBox fx:id="flagForAnnotation" mnemonicParsing="false" onAction="#handleFlagForAnnotation" stylesheets="@../css/loinc2hpo.css" text="Flag" textFill="#e40808">
-                                 <HBox.margin>
-                                    <Insets top="5.0" />
-                                 </HBox.margin>
-                              </CheckBox>
-                              <Circle fx:id="createAnnotationSuccess" fill="#f5f8fc" radius="8.0" stroke="#aba7a7" strokeType="INSIDE">
-                                 <HBox.margin>
-                                    <Insets top="5.0" />
-                                 </HBox.margin>
-                              </Circle>
-                              <Button fx:id="allAnnotationsButton" mnemonicParsing="false" onAction="#showAllAnnotations" stylesheets="@../css/loinc2hpo.css" text="All annotations">
-                                 <HBox.margin>
-                                    <Insets left="50.0" />
-                                 </HBox.margin>
-                                  <fx:include source="currentAnnotation.fxml"/>
-                              </Button>
-                           </children>
-                           <VBox.margin>
-                              <Insets left="20.0" top="20.0" />
-                           </VBox.margin>
-                        </HBox>
-                        <TextArea fx:id="annotationNoteField" prefHeight="200.0" prefWidth="200.0" promptText="Optional: note for annotation" wrapText="true">
-                           <VBox.margin>
-                              <Insets left="20.0" right="20.0" top="20.0" />
-                           </VBox.margin>
-                        </TextArea>
-                        <TreeView fx:id="treeView" onContextMenuRequested="#getContextMenu4TreeView" onDragDetected="#handleDragInTreeView" prefHeight="420.0" prefWidth="300.0" VBox.vgrow="ALWAYS">
-                           <VBox.margin>
-                              <Insets bottom="10.0" left="20.0" right="20.0" top="20.0" />
-                           </VBox.margin>
-                        </TreeView>
-                     </children>
-                  </VBox>
-               </items>
-            </SplitPane>
-            <Accordion fx:id="accordion" maxHeight="280.0" prefHeight="280.0" prefWidth="1198.0">
-              <panes>
-                <TitledPane fx:id="loincTableTitledpane" animated="false" expanded="true" text="Loinc Table">
-                  <content>
-                    <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0">
-                           <children>
-                              <TableView fx:id="loincTableView" layoutY="-7.0" maxHeight="250.0" prefHeight="250.0" prefWidth="1198.0">
-                                <columns>
-                                  <TableColumn fx:id="loincIdTableColumn" maxWidth="100.0" minWidth="60.0" prefWidth="60.0" text="LOINC" />
-                                    <TableColumn fx:id="nameTableColumn" prefWidth="140.0" text="Name" />
-                                  <TableColumn fx:id="componentTableColumn" maxWidth="250.0" minWidth="120.0" prefWidth="120.0" text="Component" />
-                                    <TableColumn fx:id="propertyTableColumn" maxWidth="80.0" minWidth="60.0" prefWidth="60.0" text="Property" />
-                                    <TableColumn fx:id="timeAspectTableColumn" maxWidth="50.0" minWidth="40.0" prefWidth="40.0" text="Time" />
-                                    <TableColumn maxWidth="50.0" minWidth="50.0" prefWidth="50.0" text="Aspect" />
-                                    <TableColumn fx:id="systemTableColumn" maxWidth="200.0" minWidth="100.0" prefWidth="100.0" text="System" />
-                                    <TableColumn fx:id="scaleTableColumn" maxWidth="80.0" minWidth="70.0" prefWidth="75.0" text="Scale" />
-                                    <TableColumn fx:id="methodTableColumn" prefWidth="75.0" text="Method" />
-                                </columns>
-                                 <columnResizePolicy>
-                                    <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
-                                 </columnResizePolicy>
+                              <Label fx:id="annotationLeftLabel" prefHeight="30.0" text="&lt;Low threshold" textFill="#0e1ccf" GridPane.halignment="CENTER">
+                                 <font>
+                                    <Font name="System Bold" size="13.0" />
+                                 </font>
                                  <padding>
-                                    <Insets bottom="80.0" />
+                                    <Insets top="10.0" />
                                  </padding>
-                              </TableView>
+                              </Label>
+                              <Label fx:id="annotationMiddleLabel" prefHeight="30.0" text="intermediant" GridPane.columnIndex="1" GridPane.halignment="CENTER" />
+                              <Label fx:id="annotationRightLabel" text="&gt;High threshold" textFill="#c71010" GridPane.columnIndex="2" GridPane.halignment="CENTER">
+                                 <font>
+                                    <Font name="System Bold" size="13.0" />
+                                 </font>
+                              </Label>
+                              <TextField fx:id="annotationTextFieldLeft" onDragDropped="#handleHPOLowAbnormality" onDragEntered="#handleDragEnterLowAbnorm" onDragExited="#handleDragExitLowAbnorm" promptText="phenotype for too low" GridPane.rowIndex="1">
+                                 <GridPane.margin>
+                                    <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                                 </GridPane.margin></TextField>
+                              <TextField fx:id="annotationTextFieldMiddle" onDragDropped="#handleParentAbnormality" onDragEntered="#handleDragEnterParentAbnorm" onDragExited="#handleDragExitParentAbnorm" promptText="parent phenotype" GridPane.columnIndex="1" GridPane.rowIndex="1">
+                                 <GridPane.margin>
+                                    <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                                 </GridPane.margin></TextField>
+                              <TextField fx:id="annotationTextFieldRight" onDragDropped="#handleHPOHighAbnormality" onDragEntered="#handleDragEnterHighAbnorm" onDragExited="#handleDragExitHighAbnorm" promptText="phenotype for too high" GridPane.columnIndex="2" GridPane.rowIndex="1">
+                                 <GridPane.margin>
+                                    <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                                 </GridPane.margin></TextField>
+                              <CheckBox fx:id="inverseChecker" mnemonicParsing="false" selected="true" text="inverse" GridPane.columnIndex="1" GridPane.halignment="CENTER" GridPane.rowIndex="2">
+                                 <padding>
+                                    <Insets left="9.0" />
+                                 </padding>
+                              </CheckBox>
+                              <Button fx:id="modeButton" mnemonicParsing="false" onAction="#annotationModeSwitchButton" stylesheets="@../css/loinc2hpo.css" text="advanced &gt;&gt;&gt;" GridPane.columnIndex="2" GridPane.rowIndex="2">
+                                 <GridPane.margin>
+                                    <Insets />
+                                 </GridPane.margin>
+                              </Button>
+                              <Button mnemonicParsing="false" onAction="#handleAnnotateCodedValue" stylesheets="@../css/loinc2hpo.css" text="+" GridPane.columnIndex="3" />
                            </children>
-                        </AnchorPane>
-                  </content>
-                </TitledPane>
-                <TitledPane fx:id="advancedAnnotationTitledPane" animated="false" text="Advanced Annotation">
-                  <content>
-                    <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0">
-                           <children>
-                              <TableView fx:id="advancedAnnotationTable" prefHeight="145.0" prefWidth="1157.0">
-                                <columns>
-                                  <TableColumn fx:id="advancedAnnotationSystem" prefWidth="461.0" text="system" />
-                                    <TableColumn fx:id="advancedAnnotationCode" prefWidth="184.0" text="code" />
-                                  <TableColumn fx:id="advancedAnnotationHpo" prefWidth="495.0" text="HPO term" />
-                                </columns>
-                              </TableView>
-                           </children></AnchorPane>
-                  </content>
-                </TitledPane>
-                <TitledPane animated="false" text="Basic Annotation">
-                  <content>
-                    <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" />
-                  </content>
-                </TitledPane>
-              </panes>
-               <padding>
-                  <Insets bottom="70.0" />
-               </padding>
-            </Accordion>
-        </items>
+                           <HBox.margin>
+                              <Insets />
+                           </HBox.margin>
+                        </GridPane>
+                     </children>
+                  </HBox>
+                  <GridPane>
+                    <columnConstraints>
+                      <ColumnConstraints hgrow="SOMETIMES" maxWidth="104.0" minWidth="10.0" prefWidth="67.0" />
+                        <ColumnConstraints hgrow="SOMETIMES" maxWidth="133.0" minWidth="10.0" prefWidth="104.0" />
+                        <ColumnConstraints hgrow="SOMETIMES" maxWidth="302.0" minWidth="10.0" prefWidth="130.0" />
+                      <ColumnConstraints hgrow="SOMETIMES" maxWidth="390.0" minWidth="10.0" prefWidth="390.0" />
+                    </columnConstraints>
+                    <rowConstraints>
+                      <RowConstraints minHeight="20.0" />
+                    </rowConstraints>
+                     <children>
+                         <Label text="Score">
+                           <GridPane.margin>
+                              <Insets left="5.0" />
+                           </GridPane.margin>
+                        </Label>
+                        <Label text="ID" GridPane.columnIndex="1">
+                           <GridPane.margin>
+                              <Insets left="5.0" />
+                           </GridPane.margin>
+                        </Label>
+                        <Label text="label" GridPane.columnIndex="2">
+                           <GridPane.margin>
+                              <Insets left="5.0" />
+                           </GridPane.margin>
+                        </Label>
+                        <Label text="definition" GridPane.columnIndex="3">
+                           <GridPane.margin>
+                              <Insets left="5.0" />
+                           </GridPane.margin>
+                        </Label>
+                     </children>
+                     <padding>
+                        <Insets bottom="5.0" left="5.0" right="5.0" top="10.0" />
+                     </padding>
+                  </GridPane>
+                  <ListView fx:id="hpoListView" onDragDetected="#handleCandidateHPODragged" onMouseClicked="#handleCandidateHPODoubleClick" VBox.vgrow="ALWAYS">
+                     <contextMenu>
+                        <ContextMenu fx:id="contextMenu">
+                          <items>
+                              <MenuItem mnemonicParsing="false" text="Review" />
+                            <MenuItem mnemonicParsing="false" onAction="#suggestNewChildTerm" text="Suggest child term" />
+                          </items>
+                        </ContextMenu>
+                     </contextMenu>
+                  </ListView>
+                  <HBox prefHeight="0.0" prefWidth="737.0">
+                     <children>
+                        <Button mnemonicParsing="false" onAction="#handleAutoQueryButton" stylesheets="@../css/loinc2hpo.css" text="Auto Query">
+                           <HBox.margin>
+                              <Insets bottom="5.0" left="20.0" top="10.0" />
+                           </HBox.margin>
+                        </Button>
+                        <Button mnemonicParsing="false" onAction="#handleManualQueryButton" stylesheets="@../css/loinc2hpo.css" text="Manual Query">
+                           <HBox.margin>
+                              <Insets bottom="5.0" left="20.0" top="10.0" />
+                           </HBox.margin>
+                        </Button>
+                        <TextField fx:id="userInputForManualQuery" onAction="#handleManualQueryButton" prefHeight="37.0" prefWidth="330.0" promptText="comma seperated keys" stylesheets="@../css/loinc2hpo.css" HBox.hgrow="ALWAYS">
+                           <HBox.margin>
+                              <Insets bottom="5.0" left="20.0" top="10.0" />
+                           </HBox.margin>
+                        </TextField>
+                        <Button fx:id="suggestHPOButton" mnemonicParsing="false" onAction="#suggestNewTerm" prefWidth="190.0" stylesheets="@../css/loinc2hpo.css" text="Suggest New HPO term">
+                           <HBox.margin>
+                              <Insets left="5.0" right="5.0" top="10.0" />
+                           </HBox.margin>
+                        </Button>
+                     </children>
+                     <VBox.margin>
+                        <Insets />
+                     </VBox.margin>
+                  </HBox>
+               </children>
+            </VBox>
+            <VBox>
+               <children>
+                  <HBox spacing="20.0">
+                     <children>
+                        <Button fx:id="createAnnotationButton" mnemonicParsing="false" onAction="#createLoinc2HpoAnnotation" stylesheets="@../css/loinc2hpo.css" text="Create annotation" />
+                        <CheckBox fx:id="flagForAnnotation" mnemonicParsing="false" onAction="#handleFlagForAnnotation" stylesheets="@../css/loinc2hpo.css" text="Flag" textFill="#e40808">
+                           <HBox.margin>
+                              <Insets top="5.0" />
+                           </HBox.margin>
+                        </CheckBox>
+                        <Circle fx:id="createAnnotationSuccess" fill="#f5f8fc" radius="8.0" stroke="#aba7a7" strokeType="INSIDE">
+                           <HBox.margin>
+                              <Insets top="5.0" />
+                           </HBox.margin>
+                        </Circle>
+                        <Button fx:id="allAnnotationsButton" mnemonicParsing="false" onAction="#showAllAnnotations" stylesheets="@../css/loinc2hpo.css" text="All annotations">
+                           <HBox.margin>
+                              <Insets left="50.0" />
+                           </HBox.margin>
+                            <fx:include source="currentAnnotation.fxml" />
+                        </Button>
+                     </children>
+                     <VBox.margin>
+                        <Insets left="20.0" top="20.0" />
+                     </VBox.margin>
+                  </HBox>
+                  <TextArea fx:id="annotationNoteField" promptText="Optional: note for annotation" wrapText="true" VBox.vgrow="NEVER">
+                     <VBox.margin>
+                        <Insets left="20.0" right="20.0" top="20.0" />
+                     </VBox.margin>
+                  </TextArea>
+                  <TreeView fx:id="treeView" onContextMenuRequested="#getContextMenu4TreeView" onDragDetected="#handleDragInTreeView" VBox.vgrow="ALWAYS">
+                     <VBox.margin>
+                        <Insets bottom="10.0" left="20.0" right="20.0" top="20.0" />
+                     </VBox.margin>
+                  </TreeView>
+               </children>
+            </VBox>
+         </items>
       </SplitPane>
-   </children>
-</AnchorPane>
+      <Accordion fx:id="accordion">
+        <panes>
+          <TitledPane fx:id="loincTableTitledpane" animated="false" expanded="true" text="Loinc Table">
+            <content>
+              <AnchorPane minHeight="0.0" minWidth="0.0">
+                     <children>
+                        <TableView fx:id="loincTableView" layoutY="-7.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                          <columns>
+                            <TableColumn fx:id="loincIdTableColumn" maxWidth="100.0" minWidth="60.0" prefWidth="60.0" text="LOINC" />
+                              <TableColumn fx:id="nameTableColumn" prefWidth="140.0" text="Name" />
+                            <TableColumn fx:id="componentTableColumn" maxWidth="250.0" minWidth="120.0" prefWidth="120.0" text="Component" />
+                              <TableColumn fx:id="propertyTableColumn" maxWidth="80.0" minWidth="60.0" prefWidth="60.0" text="Property" />
+                              <TableColumn fx:id="timeAspectTableColumn" maxWidth="50.0" minWidth="40.0" prefWidth="40.0" text="Time" />
+                              <TableColumn maxWidth="50.0" minWidth="50.0" prefWidth="50.0" text="Aspect" />
+                              <TableColumn fx:id="systemTableColumn" maxWidth="200.0" minWidth="100.0" prefWidth="100.0" text="System" />
+                              <TableColumn fx:id="scaleTableColumn" maxWidth="80.0" minWidth="70.0" prefWidth="75.0" text="Scale" />
+                              <TableColumn fx:id="methodTableColumn" prefWidth="75.0" text="Method" />
+                          </columns>
+                           <columnResizePolicy>
+                              <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
+                           </columnResizePolicy>
+                        </TableView>
+                     </children>
+                  </AnchorPane>
+            </content>
+          </TitledPane>
+          <TitledPane fx:id="advancedAnnotationTitledPane" animated="false" text="Advanced Annotation">
+            <content>
+              <AnchorPane>
+                     <children>
+                        <TableView fx:id="advancedAnnotationTable" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                          <columns>
+                            <TableColumn fx:id="advancedAnnotationSystem" prefWidth="461.0" text="system" />
+                              <TableColumn fx:id="advancedAnnotationCode" prefWidth="184.0" text="code" />
+                            <TableColumn fx:id="advancedAnnotationHpo" prefWidth="495.0" text="HPO term" />
+                          </columns>
+                        </TableView>
+                     </children>
+                  </AnchorPane>
+            </content>
+          </TitledPane>
+          <TitledPane animated="false" text="Basic Annotation">
+            <content>
+              <AnchorPane />
+            </content>
+          </TitledPane>
+        </panes>
+         <padding>
+            <Insets bottom="70.0" />
+         </padding>
+      </Accordion>
+  </items>
+</SplitPane>

--- a/loinc2hpogui/src/main/resources/fxml/currentAnnotation.fxml
+++ b/loinc2hpogui/src/main/resources/fxml/currentAnnotation.fxml
@@ -8,27 +8,30 @@
 <?import javafx.scene.control.TableView?>
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.layout.AnchorPane?>
-<?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
 
-<BorderPane fx:id="currentAnnotationPane" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="600.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/9" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.monarchinitiative.loinc2hpo.controller.CurrentAnnotationController">
-   <top>
-      <Label fx:id="annotationTitle" stylesheets="@../css/loinc2hpo.css" text="Annotation" BorderPane.alignment="CENTER">
-         <BorderPane.margin>
-            <Insets top="20.0" />
-         </BorderPane.margin></Label>
-   </top>
-   <center>
-      <SplitPane dividerPositions="0.4983277591973244" prefHeight="160.0" prefWidth="200.0" BorderPane.alignment="CENTER">
+
+<AnchorPane xmlns="http://javafx.com/javafx/8.0.111" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.monarchinitiative.loinc2hpo.controller.CurrentAnnotationController">
+   <children>
+      <Label fx:id="annotationTitle" stylesheets="@../css/loinc2hpo.css" text="Annotation" AnchorPane.leftAnchor="5.0" AnchorPane.topAnchor="5.0" />
+      <SplitPane dividerPositions="0.4983277591973244" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="40.0">
         <items>
-          <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="160.0" prefWidth="100.0">
+          <AnchorPane>
                <children>
                   <VBox prefHeight="373.0" prefWidth="294.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                      <children>
-                        <Label text="internal coding system" />
-                        <TextField fx:id="internalCodingSystem" />
-                        <TableView fx:id="internalTableview" prefHeight="200.0" prefWidth="259.0">
+                        <Label text="internal coding system">
+                           <padding>
+                              <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                           </padding>
+                        </Label>
+                        <TextField fx:id="internalCodingSystem">
+                           <VBox.margin>
+                              <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                           </VBox.margin>
+                        </TextField>
+                        <TableView fx:id="internalTableview" VBox.vgrow="ALWAYS">
                           <columns>
                             <TableColumn fx:id="codeInternalTableview" prefWidth="-1.0" text="code" />
                             <TableColumn fx:id="hpoInternalTableview" prefWidth="142.0" text="hpoTerm" />
@@ -43,10 +46,13 @@
                         </TableView>
                         <Label text="external codings">
                            <VBox.margin>
-                              <Insets top="20.0" />
+                              <Insets />
                            </VBox.margin>
+                           <padding>
+                              <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                           </padding>
                         </Label>
-                        <TableView fx:id="externalTableview" prefHeight="198.0" prefWidth="200.0">
+                        <TableView fx:id="externalTableview" VBox.vgrow="ALWAYS">
                            <columns>
                               <TableColumn fx:id="systemExternalTableview" prefWidth="75.0" text="system" />
                               <TableColumn fx:id="codeExternalTableview" prefWidth="75.0" text="code" />
@@ -64,12 +70,16 @@
                   <Insets left="5.0" right="5.0" />
                </padding>
             </AnchorPane>
-          <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="373.0" prefWidth="306.0">
+          <AnchorPane>
                <children>
-                  <VBox prefHeight="373.0" prefWidth="296.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                  <VBox AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                      <children>
-                        <Label text="interpretation codings" />
-                        <TableView fx:id="interpretationTableview" prefHeight="382.0" prefWidth="396.0">
+                        <Label text="interpretation codings">
+                           <padding>
+                              <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                           </padding>
+                        </Label>
+                        <TableView fx:id="interpretationTableview" VBox.vgrow="ALWAYS">
                            <columns>
                               <TableColumn fx:id="systemInterpretTableview" prefWidth="75.0" text="system" />
                               <TableColumn fx:id="codeInterpretTableview" prefWidth="75.0" text="code" />
@@ -80,26 +90,26 @@
                               <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
                            </columnResizePolicy>
                         </TableView>
-                        <HBox alignment="BASELINE_LEFT" prefWidth="200.0">
+                        <HBox alignment="CENTER">
                            <children>
-                              <Button mnemonicParsing="false" onAction="#setReferences" stylesheets="@../css/loinc2hpo.css" text="Reference range">
+                              <Button mnemonicParsing="false" onAction="#setReferences" prefWidth="150.0" stylesheets="@../css/loinc2hpo.css" text="Reference range">
                                  <HBox.margin>
-                                    <Insets />
+                                    <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
                                  </HBox.margin>
                               </Button>
                               <Button mnemonicParsing="false" onAction="#handleEdit" stylesheets="@../css/loinc2hpo.css" text="Edit">
                                  <HBox.margin>
-                                    <Insets left="150.0" />
+                                    <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
                                  </HBox.margin>
                               </Button>
                               <Button mnemonicParsing="false" onAction="#handleSave" stylesheets="@../css/loinc2hpo.css" text="Save">
                                  <HBox.margin>
-                                    <Insets left="20.0" />
+                                    <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
                                  </HBox.margin>
                               </Button>
                            </children>
                            <VBox.margin>
-                              <Insets top="50.0" />
+                              <Insets />
                            </VBox.margin>
                         </HBox>
                      </children>
@@ -110,9 +120,6 @@
                </children>
             </AnchorPane>
         </items>
-         <BorderPane.margin>
-            <Insets top="20.0" />
-         </BorderPane.margin>
       </SplitPane>
-   </center>
-</BorderPane>
+   </children>
+</AnchorPane>

--- a/loinc2hpogui/src/main/resources/fxml/loinc2HpoAnnotationsTab.fxml
+++ b/loinc2hpogui/src/main/resources/fxml/loinc2HpoAnnotationsTab.fxml
@@ -7,31 +7,28 @@
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.VBox?>
 
-<AnchorPane fx:id="loinc2HpoAnnotationsTab" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="800.0" prefWidth="1200.0" xmlns="http://javafx.com/javafx/9" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.monarchinitiative.loinc2hpo.controller.Loinc2HpoAnnotationsTabController">
-    <children>
-        <SplitPane dividerPositions="0.5" orientation="VERTICAL" prefHeight="800.0" prefWidth="1200.0">
-            <items>
-                <VBox fx:id="vbox4wv" alignment="CENTER" prefWidth="1200.0" />
-            <AnchorPane prefHeight="200.0" prefWidth="200.0">
-               <children>
-                  <Button mnemonicParsing="false" onAction="#deleteLoincAnnotation" stylesheets="@../css/loinc2hpo.css" text="Delete Item" AnchorPane.topAnchor="2.0" />
-                      <TableView fx:id="loincAnnotationTableView" prefWidth="1200.0" AnchorPane.bottomAnchor="0.0" AnchorPane.topAnchor="30.0">
-                          <columns>
-                        <TableColumn fx:id="loincFlagColumn" prefWidth="50.0" resizable="false" text="Flag" />
-                              <TableColumn fx:id="loincNumberColumn" prefWidth="150.0" resizable="false" text="LOINC Num" />
-                        <TableColumn fx:id="loincScaleColumn" resizable="false" text="Scale" />
-                              <TableColumn fx:id="belowNormalHpoColumn" prefWidth="200.0" resizable="false" text="Below normal" />
-                              <TableColumn fx:id="notAbnormalHpoColumn" prefWidth="200.0" resizable="false" text="Normal" />
-                              <TableColumn fx:id="aboveNormalHpoColumn" prefWidth="200.0" resizable="false" text="Above normal" />
-                        <TableColumn fx:id="noteColumn" minWidth="75.0" text="Note" />
-                          </columns>
-                     <columnResizePolicy>
-                        <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
-                     </columnResizePolicy>
-                      </TableView>
-               </children>
-            </AnchorPane>
-            </items>
-        </SplitPane>
-    </children>
-</AnchorPane>
+
+  <SplitPane dividerPositions="0.5" orientation="VERTICAL" xmlns="http://javafx.com/javafx/8.0.111" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.monarchinitiative.loinc2hpo.controller.Loinc2HpoAnnotationsTabController">
+      <items>
+          <VBox fx:id="vbox4wv" alignment="CENTER" />
+      <AnchorPane>
+         <children>
+            <Button mnemonicParsing="false" onAction="#deleteLoincAnnotation" stylesheets="@../css/loinc2hpo.css" text="Delete Item" AnchorPane.leftAnchor="5.0" AnchorPane.topAnchor="5.0" />
+                <TableView fx:id="loincAnnotationTableView" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="40.0">
+                    <columns>
+                  <TableColumn fx:id="loincFlagColumn" prefWidth="50.0" resizable="false" text="Flag" />
+                        <TableColumn fx:id="loincNumberColumn" prefWidth="150.0" resizable="false" text="LOINC Num" />
+                  <TableColumn fx:id="loincScaleColumn" resizable="false" text="Scale" />
+                        <TableColumn fx:id="belowNormalHpoColumn" prefWidth="200.0" resizable="false" text="Below normal" />
+                        <TableColumn fx:id="notAbnormalHpoColumn" prefWidth="200.0" resizable="false" text="Normal" />
+                        <TableColumn fx:id="aboveNormalHpoColumn" prefWidth="200.0" resizable="false" text="Above normal" />
+                  <TableColumn fx:id="noteColumn" minWidth="75.0" text="Note" />
+                    </columns>
+               <columnResizePolicy>
+                  <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
+               </columnResizePolicy>
+                </TableView>
+         </children>
+      </AnchorPane>
+      </items>
+  </SplitPane>

--- a/loinc2hpogui/src/main/resources/fxml/loinc2HpoConversionTab.fxml
+++ b/loinc2hpogui/src/main/resources/fxml/loinc2HpoConversionTab.fxml
@@ -1,73 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.ListView?>
 <?import javafx.scene.control.SplitPane?>
 <?import javafx.scene.layout.AnchorPane?>
-<?import javafx.scene.layout.VBox?>
 
-<AnchorPane prefHeight="800.0" prefWidth="1200.0" xmlns="http://javafx.com/javafx/9" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.monarchinitiative.loinc2hpo.controller.Loinc2HpoConversionTabController">
-   <children>
-      <SplitPane dividerPositions="0.4991652754590985" layoutY="93.0" prefHeight="700.0" prefWidth="1200.0">
-        <items>
-          <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="160.0" prefWidth="100.0">
-               <children>
-                  <VBox prefHeight="700.0" prefWidth="550.0">
-                     <children>
-                        <Button fx:id="importPatientDataButton" mnemonicParsing="false" onAction="#handleImportantPatientData" stylesheets="@../css/loinc2hpo.css" text="import patient data">
-                           <VBox.margin>
-                              <Insets top="10.0" />
-                           </VBox.margin>
-                        </Button>
-                        <ListView fx:id="patientRecordListView" prefHeight="600.0" prefWidth="500.0">
-                           <VBox.margin>
-                              <Insets top="10.0" />
-                           </VBox.margin>
-                        </ListView>
-                        <Label alignment="CENTER" contentDisplay="CENTER" prefWidth="500.0" text="Patient Loinc Test Results" textAlignment="CENTER">
-                           <VBox.margin>
-                              <Insets top="20.0" />
-                           </VBox.margin>
-                        </Label>
-                     </children>
-                     <padding>
-                        <Insets left="20.0" />
-                     </padding>
-                  </VBox>
-               </children>
-            </AnchorPane>
-          <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="800.0" prefWidth="600.0">
-               <children>
-                  <VBox prefHeight="700.0" prefWidth="550.0">
-                     <children>
-                        <Button fx:id="convertButton" mnemonicParsing="false" onAction="#handleConvertButton" stylesheets="@../css/loinc2hpo.css" text="Convert">
-                           <VBox.margin>
-                              <Insets left="10.0" top="10.0" />
-                           </VBox.margin>
-                        </Button>
-                        <ListView fx:id="patientPhenotypeTableView" prefHeight="600.0" prefWidth="500.0">
-                           <VBox.margin>
-                              <Insets top="10.0" />
-                           </VBox.margin>
-                        </ListView>
-                        <Label alignment="CENTER" contentDisplay="CENTER" prefWidth="500.0" text="Patient Loinc Test Results" textAlignment="CENTER">
-                           <VBox.margin>
-                              <Insets top="20.0" />
-                           </VBox.margin>
-                        </Label>
-                     </children>
-                     <padding>
-                        <Insets left="50.0" />
-                     </padding>
-                  </VBox>
-               </children>
-               <padding>
-                  <Insets left="600.0" />
-               </padding>
-            </AnchorPane>
-        </items>
-      </SplitPane>
-   </children>
-</AnchorPane>
+
+<SplitPane dividerPositions="0.4991652754590985" xmlns="http://javafx.com/javafx/8.0.111" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.monarchinitiative.loinc2hpo.controller.Loinc2HpoConversionTabController">
+  <items>
+    <AnchorPane>
+         <children>
+            <Button fx:id="importPatientDataButton" layoutX="20.0" layoutY="10.0" mnemonicParsing="false" onAction="#handleImportantPatientData" stylesheets="@../css/loinc2hpo.css" text="import patient data" AnchorPane.leftAnchor="20.0" AnchorPane.topAnchor="10.0" />
+            <ListView fx:id="patientRecordListView" layoutX="20.0" layoutY="46.0" AnchorPane.bottomAnchor="40.0" AnchorPane.leftAnchor="20.0" AnchorPane.rightAnchor="20.0" AnchorPane.topAnchor="50.0" />
+            <Label alignment="CENTER" contentDisplay="CENTER" layoutX="20.0" layoutY="666.0" text="Patient Loinc Test Results" textAlignment="CENTER" AnchorPane.bottomAnchor="10.0" AnchorPane.leftAnchor="20.0" AnchorPane.rightAnchor="20.0" />
+         </children>
+      </AnchorPane>
+    <AnchorPane>
+         <children>
+            <Button fx:id="convertButton" layoutX="60.0" layoutY="10.0" mnemonicParsing="false" onAction="#handleConvertButton" stylesheets="@../css/loinc2hpo.css" text="Convert" AnchorPane.leftAnchor="20.0" AnchorPane.topAnchor="10.0" />
+            <ListView fx:id="patientPhenotypeTableView" layoutX="50.0" layoutY="46.0" AnchorPane.bottomAnchor="40.0" AnchorPane.leftAnchor="20.0" AnchorPane.rightAnchor="20.0" AnchorPane.topAnchor="50.0" />
+            <Label alignment="CENTER" contentDisplay="CENTER" layoutX="50.0" layoutY="666.0" text="Patient Loinc Test Results" textAlignment="CENTER" AnchorPane.bottomAnchor="10.0" AnchorPane.leftAnchor="20.0" AnchorPane.rightAnchor="20.0" />
+         </children>
+      </AnchorPane>
+  </items>
+</SplitPane>

--- a/loinc2hpogui/src/main/resources/fxml/main.fxml
+++ b/loinc2hpogui/src/main/resources/fxml/main.fxml
@@ -5,79 +5,75 @@
 <?import javafx.scene.control.MenuItem?>
 <?import javafx.scene.control.Tab?>
 <?import javafx.scene.control.TabPane?>
-<?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.Region?>
 
-<AnchorPane fx:id="pane" prefHeight="800.0" prefWidth="1200.0" xmlns="http://javafx.com/javafx/9" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.monarchinitiative.loinc2hpo.controller.MainController">
-   <children>
-      <BorderPane prefHeight="800.0" prefWidth="1200.0">
-         <top>
-            <HBox maxWidth="1.7976931348623157E308" prefHeight="29.0" prefWidth="722.0" BorderPane.alignment="CENTER">
-               <children>
-                  <MenuBar fx:id="loincmenubar" HBox.hgrow="NEVER">
-                    <menus>
-                      <Menu mnemonicParsing="false" text="File">
-                        <items>
-                              <MenuItem mnemonicParsing="false" onAction="#handleSave" text="Save" />
-                              <MenuItem mnemonicParsing="false" onAction="#handleSaveAsButton" text="Save As" />
-                              <MenuItem mnemonicParsing="false" onAction="#handleAppendToButton" text="Append To" />
-                          <MenuItem mnemonicParsing="false" onAction="#close" text="Close" />
-                              <MenuItem fx:id="importAnnotationButton" mnemonicParsing="false" onAction="#handleImportAnnotationFile" text="Import Annotation File" />
-                              <Menu fx:id="exportMenu" mnemonicParsing="false" text="Export As...">
-                                <items>
-                                    <MenuItem mnemonicParsing="false" onAction="#handleExportAsTSV" text=".tsv" />
-                                  <MenuItem mnemonicParsing="false" text=".json" />
-                                </items>
-                              </Menu>
-                        </items>
-                      </Menu>
-                      <Menu mnemonicParsing="false" text="Edit">
-                        <items>
-                          <MenuItem mnemonicParsing="false" onAction="#setPathToLoincCoreTableFile" text="Set path to LOINC Core Table file" />
-                              <MenuItem mnemonicParsing="false" onAction="#downloadHPO" text="Download HPO file" />
-                              <MenuItem mnemonicParsing="false" onAction="#setBiocuratorID" text="Set biocurator ID" />
-                              <MenuItem mnemonicParsing="false" onAction="#openSettingsDialog" text="Show settings" />
-                        </items>
-                      </Menu>
-                    </menus>
-                  </MenuBar>
-                  <Region prefHeight="50.0" prefWidth="384.0" styleClass="menu-bar" HBox.hgrow="ALWAYS" />
-                  <MenuBar HBox.hgrow="NEVER">
-                    <menus>
-                      <Menu mnemonicParsing="false" text="Help">
-                        <items>
-                              <MenuItem mnemonicParsing="false" onAction="#openHelpDialog" text="Help" />
-                          <MenuItem mnemonicParsing="false" onAction="#aboutWindow" text="About" />
-                        </items>
-                      </Menu>
-                    </menus>
-                  </MenuBar>
-               </children>
-            </HBox>
-         </top>
-         <center>
-            <TabPane fx:id="tabPane" tabClosingPolicy="UNAVAILABLE" BorderPane.alignment="CENTER">
-              <tabs>
-                  <Tab fx:id="annotateTabButton" text="Annotate">
-                      <content>
-                          <fx:include fx:id="annotateTab" source="annotateTab.fxml" />
-                      </content>
-                  </Tab>
-                <Tab fx:id="Loinc2HPOAnnotationsTabButton" text="Loinc2HpoAnnotations">
-                    <content>
-                        <fx:include fx:id="loinc2HpoAnnotationsTab" source="loinc2HpoAnnotationsTab.fxml" />
-                    </content>
-                </Tab>
-                  <Tab fx:id="Loinc2HpoConversionTabButton" text="Loinc2HpoConversion">
-                    <content>
-                      <fx:include fx:id="Loinc2HpoConversionTab" source="loinc2HpoConversionTab.fxml" />
-                    </content>
-                  </Tab>
-            </tabs>
-            </TabPane>
-         </center>
-      </BorderPane>
-   </children>
-</AnchorPane>
+
+<BorderPane xmlns="http://javafx.com/javafx/8.0.121" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.monarchinitiative.loinc2hpo.controller.MainController">
+   <top>
+      <HBox maxHeight="30.0" BorderPane.alignment="CENTER">
+         <children>
+            <MenuBar fx:id="loincmenubar" HBox.hgrow="NEVER">
+              <menus>
+                <Menu mnemonicParsing="false" text="File">
+                  <items>
+                        <MenuItem mnemonicParsing="false" onAction="#handleSave" text="Save" />
+                        <MenuItem mnemonicParsing="false" onAction="#handleSaveAsButton" text="Save As" />
+                        <MenuItem mnemonicParsing="false" onAction="#handleAppendToButton" text="Append To" />
+                    <MenuItem mnemonicParsing="false" onAction="#close" text="Close" />
+                        <MenuItem fx:id="importAnnotationButton" mnemonicParsing="false" onAction="#handleImportAnnotationFile" text="Import Annotation File" />
+                        <Menu fx:id="exportMenu" mnemonicParsing="false" text="Export As...">
+                          <items>
+                              <MenuItem mnemonicParsing="false" onAction="#handleExportAsTSV" text=".tsv" />
+                            <MenuItem mnemonicParsing="false" text=".json" />
+                          </items>
+                        </Menu>
+                  </items>
+                </Menu>
+                <Menu mnemonicParsing="false" text="Edit">
+                  <items>
+                    <MenuItem mnemonicParsing="false" onAction="#setPathToLoincCoreTableFile" text="Set path to LOINC Core Table file" />
+                        <MenuItem mnemonicParsing="false" onAction="#downloadHPO" text="Download HPO file" />
+                        <MenuItem mnemonicParsing="false" onAction="#setBiocuratorID" text="Set biocurator ID" />
+                        <MenuItem mnemonicParsing="false" onAction="#openSettingsDialog" text="Show settings" />
+                  </items>
+                </Menu>
+              </menus>
+            </MenuBar>
+            <Region styleClass="menu-bar" HBox.hgrow="ALWAYS" />
+            <MenuBar HBox.hgrow="NEVER">
+              <menus>
+                <Menu mnemonicParsing="false" text="Help">
+                  <items>
+                        <MenuItem mnemonicParsing="false" onAction="#openHelpDialog" text="Help" />
+                    <MenuItem mnemonicParsing="false" onAction="#aboutWindow" text="About" />
+                  </items>
+                </Menu>
+              </menus>
+            </MenuBar>
+         </children>
+      </HBox>
+   </top>
+   <center>
+      <TabPane fx:id="tabPane" tabClosingPolicy="UNAVAILABLE" BorderPane.alignment="CENTER">
+        <tabs>
+            <Tab fx:id="annotateTabButton" text="Annotate">
+                <content>
+                    <fx:include fx:id="annotateTab" source="annotateTab.fxml" />
+                </content>
+            </Tab>
+          <Tab fx:id="Loinc2HPOAnnotationsTabButton" text="Loinc2HpoAnnotations">
+              <content>
+                  <fx:include fx:id="loinc2HpoAnnotationsTab" source="loinc2HpoAnnotationsTab.fxml" />
+              </content>
+          </Tab>
+            <Tab fx:id="Loinc2HpoConversionTabButton" text="Loinc2HpoConversion">
+              <content>
+                <fx:include fx:id="Loinc2HpoConversionTab" source="loinc2HpoConversionTab.fxml" />
+              </content>
+            </Tab>
+      </tabs>
+      </TabPane>
+   </center>
+</BorderPane>


### PR DESCRIPTION
Hi Aaron,
I've adjusted some values in the FXML files and it looks like that resizing works better. 

I was trying to be sensible with resizing/grow policies of the elements and to remove redundant Panes, boxes, etc. In my opinion, there were way too many hard-coded sizes of Tables, Buttons, Panes...

Please take a look on that and tell me if something is not working as it should be. Otherwise, please feel free to accept and close this pull request.

Cheers, Daniel