### PR TITLE
Add site plugins to dependencies, remove argLine argument for surefire

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,11 +103,6 @@
         </dependency>
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
-            <artifactId>hapi-fhir-structures-dstu3</artifactId>
-            <version>3.2.0</version>
-        </dependency>
-        <dependency>
-            <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-client</artifactId>
             <version>3.2.0</version>
         </dependency>
@@ -150,6 +145,17 @@
             <version>1.1.1</version>
         </dependency>
 
+        <!--Add plugins required for building app docs which may not be installed in local Maven repo of all users-->
+        <dependency>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-project-info-reports-plugin</artifactId>
+            <version>2.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.tomdz.maven</groupId>
+            <artifactId>sphinx-maven-plugin</artifactId>
+            <version>1.0.2</version>
+        </dependency>
 
     </dependencies>
     <dependencyManagement>
@@ -238,7 +244,7 @@
                     <skipTests>false</skipTests>
                     <forkCount>3</forkCount>
                     <reuseForks>true</reuseForks>
-                    <argLine>${argLine} -Xms512m -Xmx1024m
+                    <argLine>-Xms512m -Xmx1024m
                         -Duser.language=en -Duser.region=US</argLine>
                     <systemPropertyVariables>
                         <user.language>en</user.language>


### PR DESCRIPTION
Hi Aaron,
I'm suggesting some modification to the pom file. The changes relate to the plugins required to build app documentations using `mvn site`. I have been receiving error messages, since I did not have plugins in my local maven repo.

There are also some other minor changes. 

Anyway, it isn't still possible to build the app since some tests are failing, but I don't think I'm able to do anything with that.. :)
