### PR TITLE
Ditch obo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,3 +131,9 @@ Additional changes for this version
 
 * Add a LOINC list for tests with "unspecified specimen". Messages on those should be not converted to HPO. 
 
+## v1.1.6
+
+* Add feature to allow easy addition of LOINC lists: allow user to change colors of LOINC lists
+
+* Switch to owl only
+

--- a/loinc2hpo-core/src/main/java/org/monarchinitiative/loinc2hpo/ResourceCollection.java
+++ b/loinc2hpo-core/src/main/java/org/monarchinitiative/loinc2hpo/ResourceCollection.java
@@ -9,8 +9,9 @@ import org.monarchinitiative.loinc2hpo.loinc.LOINC2HpoAnnotationImpl;
 import org.monarchinitiative.loinc2hpo.loinc.LoincEntry;
 import org.monarchinitiative.loinc2hpo.loinc.LoincId;
 import org.monarchinitiative.loinc2hpo.loinc.LoincPanel;
+import org.monarchinitiative.phenol.base.PhenolException;
 import org.monarchinitiative.phenol.formats.hpo.HpoOntology;
-import org.monarchinitiative.phenol.io.obo.hpo.HpoOboParser;
+import org.monarchinitiative.phenol.io.obo.hpo.HpOboParser;
 import org.monarchinitiative.phenol.ontology.data.Term;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 import org.slf4j.Logger;
@@ -36,6 +37,7 @@ public class ResourceCollection {
     private String annotationMapPath;
     private String loincPanelPath;
     //private String loincPanelAnnotationPath;
+    private HpoOntology hpo;
     private Map<TermId, Term> termidTermMap;
     private Map<String, Term> termnameTermMap;
     private ImmutableMap<LoincId, LoincEntry> loincEntryMap;
@@ -94,11 +96,11 @@ public class ResourceCollection {
             return this.termidTermMap;
         }
 
-        HpoOboParser hpoOboParser = new HpoOboParser(new File(this.hpoOboPath));
+        HpOboParser hpoOboParser = new HpOboParser(new File(this.hpoOboPath));
         HpoOntology hpo = null;
         try {
             hpo = hpoOboParser.parse();
-        } catch (IOException e) {
+        } catch (PhenolException e) {
             e.printStackTrace();
         }
         ImmutableMap.Builder<TermId,Term> termmap = new ImmutableMap.Builder<>();
@@ -116,11 +118,11 @@ public class ResourceCollection {
             return this.termnameTermMap;
         }
 
-        HpoOboParser hpoOboParser = new HpoOboParser(new File(this.hpoOboPath));
+        HpOboParser hpoOboParser = new HpOboParser(new File(this.hpoOboPath));
         HpoOntology hpo = null;
         try {
             hpo = hpoOboParser.parse();
-        } catch (IOException e) {
+        } catch (PhenolException e) {
             e.printStackTrace();
         }
         ImmutableMap.Builder<String,Term> termmap = new ImmutableMap.Builder<>();
@@ -152,6 +154,12 @@ public class ResourceCollection {
 
     private void addLoincPanelAnnotation(String loincPanelAnnotationPath, Map<LoincId, LoincPanel> loincPanelMap){
 
+    }
+
+    public HpoOntology getHPO() throws PhenolException {
+        HpOboParser hpOboParser = new HpOboParser(new File(this.hpoOboPath));
+        this.hpo = hpOboParser.parse();
+        return this.hpo;
     }
 
 }

--- a/loinc2hpo-core/src/main/java/org/monarchinitiative/loinc2hpo/io/HPOParser.java
+++ b/loinc2hpo-core/src/main/java/org/monarchinitiative/loinc2hpo/io/HPOParser.java
@@ -3,8 +3,9 @@ package org.monarchinitiative.loinc2hpo.io;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.monarchinitiative.phenol.base.PhenolException;
 import org.monarchinitiative.phenol.formats.hpo.HpoOntology;
-import org.monarchinitiative.phenol.io.obo.hpo.HpoOboParser;
+import org.monarchinitiative.phenol.io.obo.hpo.HpOboParser;
 
 import java.io.File;
 import java.io.IOException;
@@ -28,10 +29,10 @@ public class HPOParser {
             LOGGER.error(String.format("Unable to find HPO file at %s",path));
             return;
         }
-        final HpoOboParser parser = new HpoOboParser(f);
+        final HpOboParser parser = new HpOboParser(f);
         try {
             this.hpo = parser.parse();
-        } catch(IOException e) {
+        } catch(PhenolException e) {
             LOGGER.error(String.format("I/O error with HPO file at %s",path));
             LOGGER.error(e,e);
         }

--- a/loinc2hpo-core/src/main/java/org/monarchinitiative/loinc2hpo/io/HPOParser.java
+++ b/loinc2hpo-core/src/main/java/org/monarchinitiative/loinc2hpo/io/HPOParser.java
@@ -12,7 +12,9 @@ import java.io.IOException;
 
 /**
  * Use <a href="https://github.com/Phenomics/ontolib">ontolib</a> to parse the HPO OBO file.
+ * This class overlaps with HpoOntologyParser
  */
+@Deprecated
 public class HPOParser {
     private static final Logger LOGGER = LogManager.getLogger();
 

--- a/loinc2hpo-core/src/main/java/org/monarchinitiative/loinc2hpo/io/LoincAnnotationSerializer.java
+++ b/loinc2hpo-core/src/main/java/org/monarchinitiative/loinc2hpo/io/LoincAnnotationSerializer.java
@@ -2,8 +2,6 @@ package org.monarchinitiative.loinc2hpo.io;
 
 import org.monarchinitiative.loinc2hpo.loinc.LOINC2HpoAnnotationImpl;
 import org.monarchinitiative.loinc2hpo.loinc.LoincId;
-import org.monarchinitiative.phenol.ontology.data.ImmutableTermId;
-import org.monarchinitiative.phenol.ontology.data.ImmutableTermPrefix;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 import org.monarchinitiative.phenol.ontology.data.TermPrefix;
 
@@ -17,12 +15,12 @@ public interface LoincAnnotationSerializer {
     Map<LoincId, LOINC2HpoAnnotationImpl> parse(String filepath) throws Exception;
 
     default TermId convertToTermID(String record) {
-        TermPrefix prefix = new ImmutableTermPrefix("HP");
+        TermPrefix prefix = new TermPrefix("HP");
         if (!record.startsWith(prefix.getValue()) || record.length() <= 3) {
             return null;
         }
         String id = record.substring(3);
-        return new ImmutableTermId(prefix, id);
+        return new TermId(prefix, id);
     }
 
 

--- a/loinc2hpo-core/src/main/java/org/monarchinitiative/loinc2hpo/io/WriteToFile.java
+++ b/loinc2hpo-core/src/main/java/org/monarchinitiative/loinc2hpo/io/WriteToFile.java
@@ -3,8 +3,6 @@ package org.monarchinitiative.loinc2hpo.io;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.monarchinitiative.phenol.ontology.data.ImmutableTermId;
-import org.monarchinitiative.phenol.ontology.data.ImmutableTermPrefix;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 import org.monarchinitiative.phenol.ontology.data.TermPrefix;
 
@@ -71,12 +69,12 @@ public class WriteToFile {
 
 
     public static TermId convertToTermID(String record) {
-        TermPrefix prefix = new ImmutableTermPrefix("HP");
+        TermPrefix prefix = new TermPrefix("HP");
         if (!record.startsWith(prefix.getValue()) || record.length() <= 3) {
             logger.error("Non HPO termId is detected from TSV: " + record);
             return null;
         }
         String id = record.substring(3);
-        return new ImmutableTermId(prefix, id);
+        return new TermId(prefix, id);
     }
 }

--- a/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/ResourceCollectionTest.java
+++ b/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/ResourceCollectionTest.java
@@ -1,6 +1,7 @@
 package org.monarchinitiative.loinc2hpo;
 
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.monarchinitiative.loinc2hpo.loinc.LOINC2HpoAnnotationImpl;
 import org.monarchinitiative.loinc2hpo.loinc.LoincEntry;
@@ -14,6 +15,10 @@ import java.util.Set;
 
 import static org.junit.Assert.*;
 
+/**
+ * This class is to test the resource collection
+ */
+@Ignore
 public class ResourceCollectionTest {
 
     private static Map<LoincId, LoincEntry> loincEntryMap;

--- a/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/SharedResourceCollection.java
+++ b/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/SharedResourceCollection.java
@@ -23,8 +23,10 @@ public class SharedResourceCollection {
     static {
         resourceCollection.setLoincEntryPath(loincCoreTable);
         resourceCollection.setLoincPanelPath(loincPanels);
-        resourceCollection.setHpoOboPath(hpo_obo);
-        resourceCollection.setHpoOwlPath(hpo_owl);
+        //resourceCollection.setHpoOboPath(hpo_obo);
+        resourceCollection.setHpoOboPath(SharedResourceCollection.class.getResource("/obo/hp.obo").getPath());
+        //resourceCollection.setHpoOwlPath(hpo_owl);
+        resourceCollection.setHpoOwlPath(SharedResourceCollection.class.getResource("/hp.owl").getPath());
         resourceCollection.setAnnotationMapPath(loincAnnotationPath);
     }
 }

--- a/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/fhir/FHIRLoincPanelConversionLogic/BloodPressurePanelTest.java
+++ b/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/fhir/FHIRLoincPanelConversionLogic/BloodPressurePanelTest.java
@@ -4,6 +4,7 @@ import edu.emory.mathcs.backport.java.util.Arrays;
 import org.apache.commons.chain.web.MapEntry;
 import org.hl7.fhir.dstu3.model.*;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.monarchinitiative.loinc2hpo.Constants;
 import org.monarchinitiative.loinc2hpo.ResourceCollection;
@@ -20,6 +21,7 @@ import java.util.Map;
 
 import static org.junit.Assert.*;
 
+@Ignore
 public class BloodPressurePanelTest {
 
     private static ResourceCollection resources = SharedResourceCollection.resourceCollection;

--- a/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/fhir/FhirObservationAnalyzerTest.java
+++ b/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/fhir/FhirObservationAnalyzerTest.java
@@ -10,8 +10,9 @@ import org.monarchinitiative.loinc2hpo.codesystems.CodeSystemConvertor;
 import org.monarchinitiative.loinc2hpo.codesystems.Loinc2HPOCodedValue;
 import org.monarchinitiative.loinc2hpo.loinc.*;
 import org.monarchinitiative.loinc2hpo.testresult.LabTestOutcome;
+import org.monarchinitiative.phenol.base.PhenolException;
 import org.monarchinitiative.phenol.formats.hpo.HpoOntology;
-import org.monarchinitiative.phenol.io.obo.hpo.HpoOboParser;
+import org.monarchinitiative.phenol.io.obo.hpo.HpOboParser;
 import org.monarchinitiative.phenol.ontology.data.Term;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 
@@ -33,11 +34,11 @@ public class FhirObservationAnalyzerTest {
         observation = FhirResourceRetriever.parseJsonFile2Observation(path);
 
         String hpo_obo = FhirObservationAnalyzerTest.class.getClassLoader().getResource("obo/hp.obo").getPath();
-        HpoOboParser hpoOboParser = new HpoOboParser(new File(hpo_obo));
+        HpOboParser hpoOboParser = new HpOboParser(new File(hpo_obo));
         HpoOntology hpo = null;
         try {
             hpo = hpoOboParser.parse();
-        } catch (IOException e) {
+        } catch (PhenolException e) {
             e.printStackTrace();
         }
         ImmutableMap.Builder<String,Term> termmap = new ImmutableMap.Builder<>();

--- a/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/fhir/ObservationAnalysisFromCodedValuesTest.java
+++ b/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/fhir/ObservationAnalysisFromCodedValuesTest.java
@@ -9,8 +9,9 @@ import org.monarchinitiative.loinc2hpo.codesystems.Code;
 import org.monarchinitiative.loinc2hpo.exception.MalformedLoincCodeException;
 import org.monarchinitiative.loinc2hpo.exception.UnrecognizedCodeException;
 import org.monarchinitiative.loinc2hpo.loinc.*;
+import org.monarchinitiative.phenol.base.PhenolException;
 import org.monarchinitiative.phenol.formats.hpo.HpoOntology;
-import org.monarchinitiative.phenol.io.obo.hpo.HpoOboParser;
+import org.monarchinitiative.phenol.io.obo.hpo.HpOboParser;
 import org.monarchinitiative.phenol.ontology.data.Term;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 
@@ -49,11 +50,11 @@ public class ObservationAnalysisFromCodedValuesTest {
 
 
         String hpo_obo = FhirObservationAnalyzerTest.class.getClassLoader().getResource("obo/hp.obo").getPath();
-        HpoOboParser hpoOboParser = new HpoOboParser(new File(hpo_obo));
+        HpOboParser hpoOboParser = new HpOboParser(new File(hpo_obo));
         HpoOntology hpo = null;
         try {
             hpo = hpoOboParser.parse();
-        } catch (IOException e) {
+        } catch (PhenolException e) {
             e.printStackTrace();
         }
         ImmutableMap.Builder<String,Term> termmap = new ImmutableMap.Builder<>();

--- a/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/fhir/ObservationAnalysisFromInterpretationTest.java
+++ b/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/fhir/ObservationAnalysisFromInterpretationTest.java
@@ -9,8 +9,9 @@ import org.monarchinitiative.loinc2hpo.codesystems.Code;
 import org.monarchinitiative.loinc2hpo.exception.AmbiguousResultsFoundException;
 import org.monarchinitiative.loinc2hpo.exception.MalformedLoincCodeException;
 import org.monarchinitiative.loinc2hpo.loinc.*;
+import org.monarchinitiative.phenol.base.PhenolException;
 import org.monarchinitiative.phenol.formats.hpo.HpoOntology;
-import org.monarchinitiative.phenol.io.obo.hpo.HpoOboParser;
+import org.monarchinitiative.phenol.io.obo.hpo.HpOboParser;
 import org.monarchinitiative.phenol.ontology.data.Term;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 
@@ -41,11 +42,11 @@ public class ObservationAnalysisFromInterpretationTest {
         observations[1] = observation2;
 
         String hpo_obo = FhirObservationAnalyzerTest.class.getClassLoader().getResource("obo/hp.obo").getPath();
-        HpoOboParser hpoOboParser = new HpoOboParser(new File(hpo_obo));
+        HpOboParser hpoOboParser = new HpOboParser(new File(hpo_obo));
         HpoOntology hpo = null;
         try {
             hpo = hpoOboParser.parse();
-        } catch (IOException e) {
+        } catch (PhenolException e) {
             e.printStackTrace();
         }
         ImmutableMap.Builder<String,Term> termmap = new ImmutableMap.Builder<>();

--- a/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/fhir/ObservationAnalysisFromQnValueTest.java
+++ b/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/fhir/ObservationAnalysisFromQnValueTest.java
@@ -9,8 +9,9 @@ import org.monarchinitiative.loinc2hpo.codesystems.Code;
 import org.monarchinitiative.loinc2hpo.exception.MalformedLoincCodeException;
 import org.monarchinitiative.loinc2hpo.exception.ReferenceNotFoundException;
 import org.monarchinitiative.loinc2hpo.loinc.*;
+import org.monarchinitiative.phenol.base.PhenolException;
 import org.monarchinitiative.phenol.formats.hpo.HpoOntology;
-import org.monarchinitiative.phenol.io.obo.hpo.HpoOboParser;
+import org.monarchinitiative.phenol.io.obo.hpo.HpOboParser;
 import org.monarchinitiative.phenol.ontology.data.Term;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 
@@ -41,11 +42,11 @@ public class ObservationAnalysisFromQnValueTest {
         observations[1] = observation2;
 
         String hpo_obo = FhirObservationAnalyzerTest.class.getClassLoader().getResource("obo/hp.obo").getPath();
-        HpoOboParser hpoOboParser = new HpoOboParser(new File(hpo_obo));
+        HpOboParser hpoOboParser = new HpOboParser(new File(hpo_obo));
         HpoOntology hpo = null;
         try {
             hpo = hpoOboParser.parse();
-        } catch (IOException e) {
+        } catch (PhenolException e) {
             e.printStackTrace();
         }
         ImmutableMap.Builder<String,Term> termmap = new ImmutableMap.Builder<>();

--- a/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/io/LoincAnnotationSerializerToTSVSingleFileTest.java
+++ b/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/io/LoincAnnotationSerializerToTSVSingleFileTest.java
@@ -14,8 +14,9 @@ import org.monarchinitiative.loinc2hpo.loinc.HpoTerm4TestOutcome;
 import org.monarchinitiative.loinc2hpo.loinc.LOINC2HpoAnnotationImpl;
 import org.monarchinitiative.loinc2hpo.loinc.LoincId;
 import org.monarchinitiative.loinc2hpo.loinc.LoincScale;
+import org.monarchinitiative.phenol.base.PhenolException;
 import org.monarchinitiative.phenol.formats.hpo.HpoOntology;
-import org.monarchinitiative.phenol.io.obo.hpo.HpoOboParser;
+import org.monarchinitiative.phenol.io.obo.hpo.HpOboParser;
 import org.monarchinitiative.phenol.ontology.data.Term;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 
@@ -39,11 +40,11 @@ public class LoincAnnotationSerializerToTSVSingleFileTest {
     public static void setup() throws Exception {
 
         String hpo_obo = FhirObservationAnalyzerTest.class.getClassLoader().getResource("obo/hp.obo").getPath();
-        HpoOboParser hpoOboParser = new HpoOboParser(new File(hpo_obo));
+        HpOboParser hpoOboParser = new HpOboParser(new File(hpo_obo));
         HpoOntology hpo = null;
         try {
             hpo = hpoOboParser.parse();
-        } catch (IOException e) {
+        } catch (PhenolException e) {
             e.printStackTrace();
         }
         ImmutableMap.Builder<String,Term> termmap = new ImmutableMap.Builder<>();

--- a/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/loinc/LOINC2HpoAnnotationImplTest.java
+++ b/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/loinc/LOINC2HpoAnnotationImplTest.java
@@ -10,8 +10,9 @@ import org.monarchinitiative.loinc2hpo.codesystems.CodeSystemConvertor;
 import org.monarchinitiative.loinc2hpo.codesystems.Loinc2HPOCodedValue;
 import org.monarchinitiative.loinc2hpo.fhir.FhirObservationAnalyzerTest;
 import org.monarchinitiative.loinc2hpo.io.WriteToFile;
+import org.monarchinitiative.phenol.base.PhenolException;
 import org.monarchinitiative.phenol.formats.hpo.HpoOntology;
-import org.monarchinitiative.phenol.io.obo.hpo.HpoOboParser;
+import org.monarchinitiative.phenol.io.obo.hpo.HpOboParser;
 import org.monarchinitiative.phenol.ontology.data.Term;
 
 import java.io.BufferedReader;
@@ -36,11 +37,11 @@ public class LOINC2HpoAnnotationImplTest {
     public void testToString() throws Exception {
         Map<String, Term> hpoTermMap;
         String hpo_obo = FhirObservationAnalyzerTest.class.getClassLoader().getResource("obo/hp.obo").getPath();
-        HpoOboParser hpoOboParser = new HpoOboParser(new File(hpo_obo));
+        HpOboParser hpoOboParser = new HpOboParser(new File(hpo_obo));
         HpoOntology hpo = null;
         try {
             hpo = hpoOboParser.parse();
-        } catch (IOException e) {
+        } catch (PhenolException e) {
             e.printStackTrace();
         }
         ImmutableMap.Builder<String,Term> termmap = new ImmutableMap.Builder<>();
@@ -120,11 +121,11 @@ public class LOINC2HpoAnnotationImplTest {
 
         Map<String, Term> hpoTermMap;
         String hpo_obo = FhirObservationAnalyzerTest.class.getClassLoader().getResource("obo/hp.obo").getPath();
-        HpoOboParser hpoOboParser = new HpoOboParser(new File(hpo_obo));
+        HpOboParser hpoOboParser = new HpOboParser(new File(hpo_obo));
         HpoOntology hpo = null;
         try {
             hpo = hpoOboParser.parse();
-        } catch (IOException e) {
+        } catch (PhenolException e) {
             e.printStackTrace();
         }
         ImmutableMap.Builder<String,Term> termmap = new ImmutableMap.Builder<>();
@@ -181,11 +182,11 @@ public class LOINC2HpoAnnotationImplTest {
     public void testBuilderForAdvanced() throws Exception {
         Map<String, Term> hpoTermMap;
         String hpo_obo = FhirObservationAnalyzerTest.class.getClassLoader().getResource("obo/hp.obo").getPath();
-        HpoOboParser hpoOboParser = new HpoOboParser(new File(hpo_obo));
+        HpOboParser hpoOboParser = new HpOboParser(new File(hpo_obo));
         HpoOntology hpo = null;
         try {
             hpo = hpoOboParser.parse();
-        } catch (IOException e) {
+        } catch (PhenolException e) {
             e.printStackTrace();
         }
         ImmutableMap.Builder<String,Term> termmap = new ImmutableMap.Builder<>();
@@ -238,11 +239,11 @@ public class LOINC2HpoAnnotationImplTest {
     public void testSerializeBasicAnnotation() throws Exception {
         Map<String, Term> hpoTermMap;
         String hpo_obo = FhirObservationAnalyzerTest.class.getClassLoader().getResource("obo/hp.obo").getPath();
-        HpoOboParser hpoOboParser = new HpoOboParser(new File(hpo_obo));
+        HpOboParser hpoOboParser = new HpOboParser(new File(hpo_obo));
         HpoOntology hpo = null;
         try {
             hpo = hpoOboParser.parse();
-        } catch (IOException e) {
+        } catch (PhenolException e) {
             e.printStackTrace();
         }
         ImmutableMap.Builder<String,Term> termmap = new ImmutableMap.Builder<>();
@@ -298,11 +299,11 @@ public class LOINC2HpoAnnotationImplTest {
 
         Map<String, Term> hpoTermMap;
         String hpo_obo = FhirObservationAnalyzerTest.class.getClassLoader().getResource("obo/hp.obo").getPath();
-        HpoOboParser hpoOboParser = new HpoOboParser(new File(hpo_obo));
+        HpOboParser hpoOboParser = new HpOboParser(new File(hpo_obo));
         HpoOntology hpo = null;
         try {
             hpo = hpoOboParser.parse();
-        } catch (IOException e) {
+        } catch (PhenolException e) {
             e.printStackTrace();
         }
         ImmutableMap.Builder<String,Term> termmap = new ImmutableMap.Builder<>();

--- a/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/loinc/LOINC2HpoAnnotationImplTest.java
+++ b/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/loinc/LOINC2HpoAnnotationImplTest.java
@@ -1,10 +1,13 @@
 package org.monarchinitiative.loinc2hpo.loinc;
 
 import com.google.common.collect.ImmutableMap;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.monarchinitiative.loinc2hpo.ResourceCollection;
+import org.monarchinitiative.loinc2hpo.SharedResourceCollection;
 import org.monarchinitiative.loinc2hpo.codesystems.Code;
 import org.monarchinitiative.loinc2hpo.codesystems.CodeSystemConvertor;
 import org.monarchinitiative.loinc2hpo.codesystems.Loinc2HPOCodedValue;
@@ -31,26 +34,23 @@ public class LOINC2HpoAnnotationImplTest {
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
+    private static ResourceCollection resourceCollection;
+    private static Map<String, Term> hpoTermMap;
+
+
+    @BeforeClass
+    public static void setUp() {
+        resourceCollection = new ResourceCollection();
+        resourceCollection.setHpoOboPath(LOINC2HpoAnnotationImplTest.class.getResource("/obo/hp.obo").getPath());
+
+        hpoTermMap = resourceCollection.hpoTermMapFromName();
+    }
+
 
 
     @Test
     public void testToString() throws Exception {
-        Map<String, Term> hpoTermMap;
-        String hpo_obo = FhirObservationAnalyzerTest.class.getClassLoader().getResource("obo/hp.obo").getPath();
-        HpOboParser hpoOboParser = new HpOboParser(new File(hpo_obo));
-        HpoOntology hpo = null;
-        try {
-            hpo = hpoOboParser.parse();
-        } catch (PhenolException e) {
-            e.printStackTrace();
-        }
-        ImmutableMap.Builder<String,Term> termmap = new ImmutableMap.Builder<>();
-        if (hpo !=null) {
-            List<Term> res = hpo.getTermMap().values().stream().distinct()
-                    .collect(Collectors.toList());
-            res.forEach( term -> termmap.put(term.getName(),term));
-        }
-        hpoTermMap = termmap.build();
+
         Map<LoincId, LOINC2HpoAnnotationImpl> testmap = new HashMap<>();
 
         LoincId loincId = new LoincId("15074-8");
@@ -118,25 +118,6 @@ public class LOINC2HpoAnnotationImplTest {
     @Test
     public void testBuilderForBasicAnnotation() throws Exception {
 
-
-        Map<String, Term> hpoTermMap;
-        String hpo_obo = FhirObservationAnalyzerTest.class.getClassLoader().getResource("obo/hp.obo").getPath();
-        HpOboParser hpoOboParser = new HpOboParser(new File(hpo_obo));
-        HpoOntology hpo = null;
-        try {
-            hpo = hpoOboParser.parse();
-        } catch (PhenolException e) {
-            e.printStackTrace();
-        }
-        ImmutableMap.Builder<String,Term> termmap = new ImmutableMap.Builder<>();
-        if (hpo !=null) {
-            List<Term> res = hpo.getTermMap().values().stream().distinct()
-                    .collect(Collectors.toList());
-            res.forEach( term -> termmap.put(term.getName(),term));
-        }
-        hpoTermMap = termmap.build();
-
-
         LOINC2HpoAnnotationImpl.Builder loinc2HpoAnnotationBuilder = new LOINC2HpoAnnotationImpl.Builder();
 
         LoincId loincId = new LoincId("15074-8");
@@ -180,23 +161,6 @@ public class LOINC2HpoAnnotationImplTest {
 
     @Test
     public void testBuilderForAdvanced() throws Exception {
-        Map<String, Term> hpoTermMap;
-        String hpo_obo = FhirObservationAnalyzerTest.class.getClassLoader().getResource("obo/hp.obo").getPath();
-        HpOboParser hpoOboParser = new HpOboParser(new File(hpo_obo));
-        HpoOntology hpo = null;
-        try {
-            hpo = hpoOboParser.parse();
-        } catch (PhenolException e) {
-            e.printStackTrace();
-        }
-        ImmutableMap.Builder<String,Term> termmap = new ImmutableMap.Builder<>();
-        if (hpo !=null) {
-            List<Term> res = hpo.getTermMap().values().stream().distinct()
-                    .collect(Collectors.toList());
-            res.forEach( term -> termmap.put(term.getName(),term));
-        }
-        hpoTermMap = termmap.build();
-
 
         LOINC2HpoAnnotationImpl.Builder loinc2HpoAnnotationBuilder = new LOINC2HpoAnnotationImpl.Builder();
 
@@ -237,23 +201,6 @@ public class LOINC2HpoAnnotationImplTest {
     @Test
     @Ignore
     public void testSerializeBasicAnnotation() throws Exception {
-        Map<String, Term> hpoTermMap;
-        String hpo_obo = FhirObservationAnalyzerTest.class.getClassLoader().getResource("obo/hp.obo").getPath();
-        HpOboParser hpoOboParser = new HpOboParser(new File(hpo_obo));
-        HpoOntology hpo = null;
-        try {
-            hpo = hpoOboParser.parse();
-        } catch (PhenolException e) {
-            e.printStackTrace();
-        }
-        ImmutableMap.Builder<String,Term> termmap = new ImmutableMap.Builder<>();
-        if (hpo !=null) {
-            List<Term> res = hpo.getTermMap().values().stream().distinct()
-                    .collect(Collectors.toList());
-            res.forEach( term -> termmap.put(term.getName(),term));
-        }
-        hpoTermMap = termmap.build();
-
 
         LOINC2HpoAnnotationImpl.Builder loinc2HpoAnnotationBuilder = new LOINC2HpoAnnotationImpl.Builder();
 
@@ -295,25 +242,6 @@ public class LOINC2HpoAnnotationImplTest {
     @Test
     @Ignore
     public void testSerializeAdvancedAnnotation() throws Exception {
-
-
-        Map<String, Term> hpoTermMap;
-        String hpo_obo = FhirObservationAnalyzerTest.class.getClassLoader().getResource("obo/hp.obo").getPath();
-        HpOboParser hpoOboParser = new HpOboParser(new File(hpo_obo));
-        HpoOntology hpo = null;
-        try {
-            hpo = hpoOboParser.parse();
-        } catch (PhenolException e) {
-            e.printStackTrace();
-        }
-        ImmutableMap.Builder<String,Term> termmap = new ImmutableMap.Builder<>();
-        if (hpo !=null) {
-            List<Term> res = hpo.getTermMap().values().stream().distinct()
-                    .collect(Collectors.toList());
-            res.forEach( term -> termmap.put(term.getName(),term));
-        }
-        hpoTermMap = termmap.build();
-
 
         LOINC2HpoAnnotationImpl.Builder loinc2HpoAnnotationBuilder = new LOINC2HpoAnnotationImpl.Builder();
 

--- a/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/testresult/PatientSummaryImplTest.java
+++ b/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/testresult/PatientSummaryImplTest.java
@@ -45,37 +45,11 @@ public class PatientSummaryImplTest {
     @BeforeClass
     public static void setup() throws Exception{
         ResourceCollection resourceCollection = SharedResourceCollection.resourceCollection;
-//        String hpo_obo = "/Users/zhangx/git/human-phenotype-ontology/src/ontology/hp.obo";
-//        HpoOboParser hpoOboParser = new HpoOboParser(new File(hpo_obo));
-//        HpoOntology hpo = null;
-//        try {
-//            hpo = hpoOboParser.parse();
-//        } catch (IOException e) {
-//            e.printStackTrace();
-//        }
-//        ImmutableMap.Builder<String,Term> termmap = new ImmutableMap.Builder<>();
-//        ImmutableMap.Builder<TermId, Term> termMap2 = new ImmutableMap.Builder<>();
-//        if (hpo !=null) {
-//            List<Term> res = hpo.getTermMap().values().stream().distinct()
-//                    .collect(Collectors.toList());
-//            res.forEach( term -> {
-//                termmap.put(term.getName(),term);
-//                termMap2.put(term.getId(), term);
-//            });
-//        }
-//        hpoTermMap = termmap.build();
-//        hpoTermMap2 = termMap2.build();
+
         hpoTermMap = resourceCollection.hpoTermMapFromName();
         hpoTermMap2 = resourceCollection.hpoTermMap();
         HpoOntology hpo = resourceCollection.getHPO();
-
-        String tsvSingleFile = "/Users/zhangx/git/loinc2hpoAnnotation/Data/TSVSingleFile/annotations.tsv";
-        Map<LoincId, LOINC2HpoAnnotationImpl> annotationMap = null;
-        try {
-            annotationMap = LoincAnnotationSerializationFactory.parseFromFile(tsvSingleFile, hpoTermMap2, LoincAnnotationSerializationFactory.SerializationFormat.TSVSingleFile);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        Map<LoincId, LOINC2HpoAnnotationImpl> annotationMap = resourceCollection.annotationMap();
 
         hpoTermUnionFind = new PhenoSetUnionFind(hpo.getTermMap().values().stream().collect(Collectors.toSet()), annotationMap).getUnionFind();
 

--- a/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/testresult/PatientSummaryImplTest.java
+++ b/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/testresult/PatientSummaryImplTest.java
@@ -6,6 +6,8 @@ import org.jgrapht.alg.util.UnionFind;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.monarchinitiative.loinc2hpo.ResourceCollection;
+import org.monarchinitiative.loinc2hpo.SharedResourceCollection;
 import org.monarchinitiative.loinc2hpo.fhir.FhirResourceFaker;
 import org.monarchinitiative.loinc2hpo.fhir.FhirResourceFakerImpl;
 import org.monarchinitiative.loinc2hpo.io.LoincAnnotationSerializationFactory;
@@ -14,7 +16,6 @@ import org.monarchinitiative.loinc2hpo.loinc.LOINC2HpoAnnotationImpl;
 import org.monarchinitiative.loinc2hpo.loinc.LoincEntry;
 import org.monarchinitiative.loinc2hpo.loinc.LoincId;
 import org.monarchinitiative.phenol.formats.hpo.HpoOntology;
-import org.monarchinitiative.phenol.io.obo.hpo.HpoOboParser;
 import org.monarchinitiative.phenol.ontology.data.Term;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 
@@ -43,26 +44,30 @@ public class PatientSummaryImplTest {
 
     @BeforeClass
     public static void setup() throws Exception{
-        String hpo_obo = "/Users/zhangx/git/human-phenotype-ontology/src/ontology/hp.obo";
-        HpoOboParser hpoOboParser = new HpoOboParser(new File(hpo_obo));
-        HpoOntology hpo = null;
-        try {
-            hpo = hpoOboParser.parse();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-        ImmutableMap.Builder<String,Term> termmap = new ImmutableMap.Builder<>();
-        ImmutableMap.Builder<TermId, Term> termMap2 = new ImmutableMap.Builder<>();
-        if (hpo !=null) {
-            List<Term> res = hpo.getTermMap().values().stream().distinct()
-                    .collect(Collectors.toList());
-            res.forEach( term -> {
-                termmap.put(term.getName(),term);
-                termMap2.put(term.getId(), term);
-            });
-        }
-        hpoTermMap = termmap.build();
-        hpoTermMap2 = termMap2.build();
+        ResourceCollection resourceCollection = SharedResourceCollection.resourceCollection;
+//        String hpo_obo = "/Users/zhangx/git/human-phenotype-ontology/src/ontology/hp.obo";
+//        HpoOboParser hpoOboParser = new HpoOboParser(new File(hpo_obo));
+//        HpoOntology hpo = null;
+//        try {
+//            hpo = hpoOboParser.parse();
+//        } catch (IOException e) {
+//            e.printStackTrace();
+//        }
+//        ImmutableMap.Builder<String,Term> termmap = new ImmutableMap.Builder<>();
+//        ImmutableMap.Builder<TermId, Term> termMap2 = new ImmutableMap.Builder<>();
+//        if (hpo !=null) {
+//            List<Term> res = hpo.getTermMap().values().stream().distinct()
+//                    .collect(Collectors.toList());
+//            res.forEach( term -> {
+//                termmap.put(term.getName(),term);
+//                termMap2.put(term.getId(), term);
+//            });
+//        }
+//        hpoTermMap = termmap.build();
+//        hpoTermMap2 = termMap2.build();
+        hpoTermMap = resourceCollection.hpoTermMapFromName();
+        hpoTermMap2 = resourceCollection.hpoTermMap();
+        HpoOntology hpo = resourceCollection.getHPO();
 
         String tsvSingleFile = "/Users/zhangx/git/loinc2hpoAnnotation/Data/TSVSingleFile/annotations.tsv";
         Map<LoincId, LOINC2HpoAnnotationImpl> annotationMap = null;

--- a/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/testresult/PhenoSetImplTest.java
+++ b/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/testresult/PhenoSetImplTest.java
@@ -7,8 +7,9 @@ import org.junit.Test;
 import org.monarchinitiative.loinc2hpo.io.LoincAnnotationSerializationFactory;
 import org.monarchinitiative.loinc2hpo.loinc.LOINC2HpoAnnotationImpl;
 import org.monarchinitiative.loinc2hpo.loinc.LoincId;
+import org.monarchinitiative.phenol.base.PhenolException;
 import org.monarchinitiative.phenol.formats.hpo.HpoOntology;
-import org.monarchinitiative.phenol.io.obo.hpo.HpoOboParser;
+import org.monarchinitiative.phenol.io.obo.hpo.HpOboParser;
 import org.monarchinitiative.phenol.ontology.data.Term;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 
@@ -33,11 +34,11 @@ public class PhenoSetImplTest {
     @BeforeClass
     public static void setup() {
         String hpo_obo = "/Users/zhangx/git/human-phenotype-ontology/src/ontology/hp.obo";
-        HpoOboParser hpoOboParser = new HpoOboParser(new File(hpo_obo));
+        HpOboParser hpoOboParser = new HpOboParser(new File(hpo_obo));
         HpoOntology hpo = null;
         try {
             hpo = hpoOboParser.parse();
-        } catch (IOException e) {
+        } catch (PhenolException e) {
             e.printStackTrace();
         }
         ImmutableMap.Builder<String,Term> termmap = new ImmutableMap.Builder<>();

--- a/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/testresult/PhenoSetImplTest.java
+++ b/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/testresult/PhenoSetImplTest.java
@@ -4,6 +4,8 @@ import com.google.common.collect.ImmutableMap;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.monarchinitiative.loinc2hpo.ResourceCollection;
+import org.monarchinitiative.loinc2hpo.SharedResourceCollection;
 import org.monarchinitiative.loinc2hpo.io.LoincAnnotationSerializationFactory;
 import org.monarchinitiative.loinc2hpo.loinc.LOINC2HpoAnnotationImpl;
 import org.monarchinitiative.loinc2hpo.loinc.LoincId;
@@ -32,40 +34,16 @@ public class PhenoSetImplTest {
     private static PhenoSetUnionFind unionFind;
 
     @BeforeClass
-    public static void setup() {
-        String hpo_obo = "/Users/zhangx/git/human-phenotype-ontology/src/ontology/hp.obo";
-        HpOboParser hpoOboParser = new HpOboParser(new File(hpo_obo));
-        HpoOntology hpo = null;
-        try {
-            hpo = hpoOboParser.parse();
-        } catch (PhenolException e) {
-            e.printStackTrace();
-        }
-        ImmutableMap.Builder<String,Term> termmap = new ImmutableMap.Builder<>();
-        ImmutableMap.Builder<TermId,Term> termMap2 = new ImmutableMap.Builder<>();
-        if (hpo !=null) {
-            List<Term> res = hpo.getTermMap().values().stream().distinct()
-                    .collect(Collectors.toList());
-            res.forEach( term -> {
-                termmap.put(term.getName(),term);
-                termMap2.put(term.getId(), term);
-            });
-        }
-        hpoTermMap = termmap.build();
-        hpoTermMap2 = termMap2.build();
+    public static void setup() throws Exception {
 
-        String tsvSingleFile = "/Users/zhangx/git/loinc2hpoAnnotation/Data/TSVSingleFile/annotations.tsv";
-        try {
-            annotationMap = LoincAnnotationSerializationFactory.parseFromFile(tsvSingleFile, hpoTermMap2, LoincAnnotationSerializationFactory.SerializationFormat.TSVSingleFile);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        ResourceCollection resourceCollection = SharedResourceCollection.resourceCollection;
 
-        System.out.println("annotationMap size:" + annotationMap.size());
+        hpoTermMap = resourceCollection.hpoTermMapFromName();
+        hpoTermMap2 = resourceCollection.hpoTermMap();
+        HpoOntology hpo = resourceCollection.getHPO();
+        Map<LoincId, LOINC2HpoAnnotationImpl> annotationMap = resourceCollection.annotationMap();
 
         unionFind = new PhenoSetUnionFind(hpo.getTermMap().values().stream().collect(Collectors.toSet()), annotationMap);
-
-
 
     }
     @Test

--- a/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/testresult/PhenoSetTimeLineImplTest.java
+++ b/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/testresult/PhenoSetTimeLineImplTest.java
@@ -6,6 +6,8 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.monarchinitiative.loinc2hpo.ResourceCollection;
+import org.monarchinitiative.loinc2hpo.SharedResourceCollection;
 import org.monarchinitiative.loinc2hpo.fhir.FhirObservationAnalyzerTest;
 import org.monarchinitiative.loinc2hpo.io.LoincAnnotationSerializationFactory;
 import org.monarchinitiative.loinc2hpo.loinc.LOINC2HpoAnnotationImpl;
@@ -36,34 +38,12 @@ public class PhenoSetTimeLineImplTest {
 
     @BeforeClass
     public static void setup() throws Exception{
-        String hpo_obo = "/Users/zhangx/git/human-phenotype-ontology/src/ontology/hp.obo";
-        HpOboParser hpoOboParser = new HpOboParser(new File(hpo_obo));
-        HpoOntology hpo = null;
-        try {
-            hpo = hpoOboParser.parse();
-        } catch (PhenolException e) {
-            e.printStackTrace();
-        }
-        ImmutableMap.Builder<String,Term> termmap = new ImmutableMap.Builder<>();
-        ImmutableMap.Builder<TermId, Term> termMap2 = new ImmutableMap.Builder<>();
-        if (hpo !=null) {
-            List<Term> res = hpo.getTermMap().values().stream().distinct()
-                    .collect(Collectors.toList());
-            res.forEach( term -> {
-                termmap.put(term.getName(),term);
-                termMap2.put(term.getId(), term);
-            });
-        }
-        hpoTermMap = termmap.build();
-        hpoTermMap2 = termMap2.build();
+        ResourceCollection resourceCollection = SharedResourceCollection.resourceCollection;
 
-        String tsvSingleFile = "/Users/zhangx/git/loinc2hpoAnnotation/Data/TSVSingleFile/annotations.tsv";
-        Map<LoincId, LOINC2HpoAnnotationImpl> annotationMap = null;
-        try {
-            annotationMap = LoincAnnotationSerializationFactory.parseFromFile(tsvSingleFile, hpoTermMap2, LoincAnnotationSerializationFactory.SerializationFormat.TSVSingleFile);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        hpoTermMap = resourceCollection.hpoTermMapFromName();
+        hpoTermMap2 = resourceCollection.hpoTermMap();
+        HpoOntology hpo = resourceCollection.getHPO();
+        Map<LoincId, LOINC2HpoAnnotationImpl> annotationMap = resourceCollection.annotationMap();
 
         hpoTermUnionFind = new PhenoSetUnionFind(hpo.getTermMap().values().stream().collect(Collectors.toSet()), annotationMap).getUnionFind();
     }

--- a/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/testresult/PhenoSetTimeLineImplTest.java
+++ b/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/testresult/PhenoSetTimeLineImplTest.java
@@ -10,8 +10,9 @@ import org.monarchinitiative.loinc2hpo.fhir.FhirObservationAnalyzerTest;
 import org.monarchinitiative.loinc2hpo.io.LoincAnnotationSerializationFactory;
 import org.monarchinitiative.loinc2hpo.loinc.LOINC2HpoAnnotationImpl;
 import org.monarchinitiative.loinc2hpo.loinc.LoincId;
+import org.monarchinitiative.phenol.base.PhenolException;
 import org.monarchinitiative.phenol.formats.hpo.HpoOntology;
-import org.monarchinitiative.phenol.io.obo.hpo.HpoOboParser;
+import org.monarchinitiative.phenol.io.obo.hpo.HpOboParser;
 import org.monarchinitiative.phenol.ontology.data.Term;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 
@@ -36,11 +37,11 @@ public class PhenoSetTimeLineImplTest {
     @BeforeClass
     public static void setup() throws Exception{
         String hpo_obo = "/Users/zhangx/git/human-phenotype-ontology/src/ontology/hp.obo";
-        HpoOboParser hpoOboParser = new HpoOboParser(new File(hpo_obo));
+        HpOboParser hpoOboParser = new HpOboParser(new File(hpo_obo));
         HpoOntology hpo = null;
         try {
             hpo = hpoOboParser.parse();
-        } catch (IOException e) {
+        } catch (PhenolException e) {
             e.printStackTrace();
         }
         ImmutableMap.Builder<String,Term> termmap = new ImmutableMap.Builder<>();

--- a/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/testresult/PhenoSetUnionFindTest.java
+++ b/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/testresult/PhenoSetUnionFindTest.java
@@ -4,7 +4,8 @@ import com.google.common.collect.ImmutableMap;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.monarchinitiative.loinc2hpo.fhir.FhirObservationAnalyzerTest;
+import org.monarchinitiative.loinc2hpo.ResourceCollection;
+import org.monarchinitiative.loinc2hpo.SharedResourceCollection;
 import org.monarchinitiative.loinc2hpo.io.LoincAnnotationSerializationFactory;
 import org.monarchinitiative.loinc2hpo.loinc.LOINC2HpoAnnotationImpl;
 import org.monarchinitiative.loinc2hpo.loinc.LoincId;
@@ -15,7 +16,6 @@ import org.monarchinitiative.phenol.ontology.data.Term;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,36 +36,13 @@ public class PhenoSetUnionFindTest {
     private static PhenoSetUnionFind unionFind;
 
     @BeforeClass
-    public static void setup() {
-        String hpo_obo = "/Users/zhangx/git/human-phenotype-ontology/src/ontology/hp.obo";
-        HpOboParser hpoOboParser = new HpOboParser(new File(hpo_obo));
-        HpoOntology hpo = null;
-        try {
-            hpo = hpoOboParser.parse();
-        } catch (PhenolException e) {
-            e.printStackTrace();
-        }
-        ImmutableMap.Builder<String,Term> termmap = new ImmutableMap.Builder<>();
-        ImmutableMap.Builder<TermId, Term> termMap2 = new ImmutableMap.Builder<>();
-        if (hpo !=null) {
-            List<Term> res = hpo.getTermMap().values().stream().distinct()
-                    .collect(Collectors.toList());
-            res.forEach( term -> {
-                termmap.put(term.getName(),term);
-                termMap2.put(term.getId(), term);
-            });
-        }
-        hpoTermMap = termmap.build();
-        hpoTermMap2 = termMap2.build();
+    public static void setup() throws Exception{
+        ResourceCollection resourceCollection = SharedResourceCollection.resourceCollection;
 
-        String tsvSingleFile = "/Users/zhangx/git/loinc2hpoAnnotation/Data/TSVSingleFile/annotations.tsv";
-        try {
-            annotationMap = LoincAnnotationSerializationFactory.parseFromFile(tsvSingleFile, hpoTermMap2, LoincAnnotationSerializationFactory.SerializationFormat.TSVSingleFile);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-
-        System.out.println("annotationMap size:" + annotationMap.size());
+        hpoTermMap = resourceCollection.hpoTermMapFromName();
+        hpoTermMap2 = resourceCollection.hpoTermMap();
+        HpoOntology hpo = resourceCollection.getHPO();
+        Map<LoincId, LOINC2HpoAnnotationImpl> annotationMap = resourceCollection.annotationMap();
 
         unionFind = new PhenoSetUnionFind(hpo.getTermMap().values().stream().collect(Collectors.toSet()), annotationMap);
 

--- a/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/testresult/PhenoSetUnionFindTest.java
+++ b/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/testresult/PhenoSetUnionFindTest.java
@@ -8,8 +8,9 @@ import org.monarchinitiative.loinc2hpo.fhir.FhirObservationAnalyzerTest;
 import org.monarchinitiative.loinc2hpo.io.LoincAnnotationSerializationFactory;
 import org.monarchinitiative.loinc2hpo.loinc.LOINC2HpoAnnotationImpl;
 import org.monarchinitiative.loinc2hpo.loinc.LoincId;
+import org.monarchinitiative.phenol.base.PhenolException;
 import org.monarchinitiative.phenol.formats.hpo.HpoOntology;
-import org.monarchinitiative.phenol.io.obo.hpo.HpoOboParser;
+import org.monarchinitiative.phenol.io.obo.hpo.HpOboParser;
 import org.monarchinitiative.phenol.ontology.data.Term;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 
@@ -37,11 +38,11 @@ public class PhenoSetUnionFindTest {
     @BeforeClass
     public static void setup() {
         String hpo_obo = "/Users/zhangx/git/human-phenotype-ontology/src/ontology/hp.obo";
-        HpoOboParser hpoOboParser = new HpoOboParser(new File(hpo_obo));
+        HpOboParser hpoOboParser = new HpOboParser(new File(hpo_obo));
         HpoOntology hpo = null;
         try {
             hpo = hpoOboParser.parse();
-        } catch (IOException e) {
+        } catch (PhenolException e) {
             e.printStackTrace();
         }
         ImmutableMap.Builder<String,Term> termmap = new ImmutableMap.Builder<>();

--- a/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/testresult/PhenotypeComponentImplTest.java
+++ b/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/testresult/PhenotypeComponentImplTest.java
@@ -4,7 +4,11 @@ import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.monarchinitiative.loinc2hpo.ResourceCollection;
+import org.monarchinitiative.loinc2hpo.SharedResourceCollection;
 import org.monarchinitiative.loinc2hpo.fhir.FhirObservationAnalyzerTest;
+import org.monarchinitiative.loinc2hpo.loinc.LOINC2HpoAnnotationImpl;
+import org.monarchinitiative.loinc2hpo.loinc.LoincId;
 import org.monarchinitiative.phenol.base.PhenolException;
 import org.monarchinitiative.phenol.formats.hpo.HpoOntology;
 import org.monarchinitiative.phenol.io.obo.hpo.HpOboParser;
@@ -31,26 +35,13 @@ public class PhenotypeComponentImplTest {
 
     @BeforeClass
     public static void setup() throws Exception{
-        String hpo_obo = FhirObservationAnalyzerTest.class.getClassLoader().getResource("obo/hp.obo").getPath();
-        HpOboParser hpoOboParser = new HpOboParser(new File(hpo_obo));
-        HpoOntology hpo = null;
-        try {
-            hpo = hpoOboParser.parse();
-        } catch (PhenolException e) {
-            e.printStackTrace();
-        }
-        ImmutableMap.Builder<String,Term> termmap = new ImmutableMap.Builder<>();
-        ImmutableMap.Builder<TermId,Term> termmap2 = new ImmutableMap.Builder<>();
-        if (hpo !=null) {
-            List<Term> res = hpo.getTermMap().values().stream().distinct()
-                    .collect(Collectors.toList());
-            res.forEach( term -> {
-                termmap.put(term.getName(),term);
-                termmap2.put(term.getId(), term);
-            });
-        }
-        hpoTermMap = termmap.build();
-        hpoTermMap2 = termmap2.build();
+
+        ResourceCollection resourceCollection = SharedResourceCollection.resourceCollection;
+        //resourceCollection.setHpoOboPath(PhenotypeComponentImplTest.class.getResource("/obo/hp.obo").getPath());
+
+        hpoTermMap = resourceCollection.hpoTermMapFromName();
+        hpoTermMap2 = resourceCollection.hpoTermMap();
+
     }
 
     @Before

--- a/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/testresult/PhenotypeComponentImplTest.java
+++ b/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/testresult/PhenotypeComponentImplTest.java
@@ -5,8 +5,9 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.monarchinitiative.loinc2hpo.fhir.FhirObservationAnalyzerTest;
+import org.monarchinitiative.phenol.base.PhenolException;
 import org.monarchinitiative.phenol.formats.hpo.HpoOntology;
-import org.monarchinitiative.phenol.io.obo.hpo.HpoOboParser;
+import org.monarchinitiative.phenol.io.obo.hpo.HpOboParser;
 import org.monarchinitiative.phenol.ontology.data.Term;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 
@@ -31,11 +32,11 @@ public class PhenotypeComponentImplTest {
     @BeforeClass
     public static void setup() throws Exception{
         String hpo_obo = FhirObservationAnalyzerTest.class.getClassLoader().getResource("obo/hp.obo").getPath();
-        HpoOboParser hpoOboParser = new HpoOboParser(new File(hpo_obo));
+        HpOboParser hpoOboParser = new HpOboParser(new File(hpo_obo));
         HpoOntology hpo = null;
         try {
             hpo = hpoOboParser.parse();
-        } catch (IOException e) {
+        } catch (PhenolException e) {
             e.printStackTrace();
         }
         ImmutableMap.Builder<String,Term> termmap = new ImmutableMap.Builder<>();

--- a/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/util/SparqlQueryTest.java
+++ b/loinc2hpo-core/src/test/java/org/monarchinitiative/loinc2hpo/util/SparqlQueryTest.java
@@ -5,20 +5,30 @@ import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryFactory;
 import org.apache.jena.query.QuerySolution;
 import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFFormat;
+import org.apache.jena.shared.JenaException;
 import org.apache.jena.util.FileManager;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.monarchinitiative.loinc2hpo.util.HPO_Class_Found;
-import org.monarchinitiative.loinc2hpo.util.SparqlQuery;
+import org.semanticweb.owlapi.apibinding.OWLManager;
+import org.semanticweb.owlapi.formats.FunctionalSyntaxDocumentFormat;
+import org.semanticweb.owlapi.formats.RDFaDocumentFormat;
+import org.semanticweb.owlapi.io.FileDocumentSource;
+import org.semanticweb.owlapi.io.OWLOntologyDocumentSource;
+import org.semanticweb.owlapi.model.OWLDocumentFormat;
+import org.semanticweb.owlapi.model.OWLDocumentFormatImpl;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLOntologyManager;
+import org.semanticweb.owlapi.model.parameters.OntologyCopy;
+//import ru.avicomp.owlapi.OWLOntologyFactoryImpl;
 
 import java.io.*;
 import java.util.*;
-import java.util.regex.Pattern;
 
 import static org.junit.Assert.*;
 
@@ -63,6 +73,28 @@ public class SparqlQueryTest {
         //org.apache.jena.rdf.model.Model modelFromRDF = FileManager.get().loadModel(path, null, "TURTLE");
         //assertNotNull(modelFromRDF);
     }
+
+//    @Test
+//    @Ignore
+//    public void testLoadOwlFunctionalSyntax() throws Exception {
+//        String hpo_owl_fs = "/Users/zhangx/git/human-phenotype-ontology/src/ontology/hp-edit.owl";
+//        String hpo_owl = "/Users/zhangx/git/human-phenotype-ontology/src/ontology/hp.owl";
+//        org.apache.jena.rdf.model.Model jenaModel = ModelFactory.createDefaultModel();
+//        //InputStream inputStream = new FileInputStream(new File(hpo_owl_fs));
+//        System.out.println("11111");
+//        //OWLOntologyManager owlOntologyManager = OWLManager.createOWLOntologyManager();
+//        //OWLOntology owlOntology = owlOntologyManager.loadOntologyFromOntologyDocument(new File(hpo_owl_fs));
+//
+//        OntologyManager manager = OntManagers.createONT();
+//        OWLOntologyDocumentSource source = new FileDocumentSource(new File(hpo_owl_fs), new FunctionalSyntaxDocumentFormat());
+//        System.out.println("22222");
+//        //PipedInputStream inputStream = new PipedInputStream();
+//        //PipedOutputStream outputStream = new PipedOutputStream(inputStream);
+//        //owlOntology.saveOntology(outputStream);
+//        OntologyModel ontology = manager.loadOntologyFromOntologyDocument(source);
+//        jenaModel = ontology.asGraphModel();
+//        System.out.println("completed");
+//    }
 
     @Test
     public void testinitializeModel() {

--- a/loinc2hpogui/src/main/java/org/monarchinitiative/loinc2hpo/controller/AnnotateTabController.java
+++ b/loinc2hpogui/src/main/java/org/monarchinitiative/loinc2hpo/controller/AnnotateTabController.java
@@ -406,7 +406,7 @@ public class AnnotateTabController {
             }
         }
         logger.info("default colors in model:");
-        model.defaultColorList().forEach(System.out::println);
+        //model.defaultColorList().forEach(System.out::println);
         logger.trace("default color for LOINC lists is set");
     }
 
@@ -1157,7 +1157,7 @@ public class AnnotateTabController {
 
     @FXML private void handleCandidateHPODragged(MouseEvent e) {
 
-        System.out.println("Drag event detected");
+        //System.out.println("Drag event detected");
         Dragboard db = hpoListView.startDragAndDrop(TransferMode.ANY);
         ClipboardContent content = new ClipboardContent();
         Object selectedCell = hpoListView.getSelectionModel().getSelectedItem();
@@ -1316,6 +1316,9 @@ public class AnnotateTabController {
         if (model.getLoincAnnotationMap().containsKey(loincId)) {
             logger.trace("Overwrite: " + loincId);
         }
+        String comments = toCopy.getNote()==null ? "" : "@original comment: " + toCopy.getNote();
+        String copyInfo = String.format("copied from: %s %s", toCopy.getLoincId().toString(), comments);
+
         LOINC2HpoAnnotationImpl.Builder builder = new LOINC2HpoAnnotationImpl.Builder()
                 .setLoincId(loincId)
                 .setLoincScale(toCopy.getLoincScale())
@@ -1323,7 +1326,7 @@ public class AnnotateTabController {
                 .setCreatedOn(toCopy.getCreatedOn())
                 .setLastEditedBy(toCopy.getLastEditedBy())
                 .setLastEditedOn(toCopy.getLastEditedOn())
-                .setNote(toCopy.getNote())
+                .setNote(copyInfo)
                 .setFlag(toCopy.getFlag())
                 .setVersion(toCopy.getVersion());
         toCopy.getCandidateHpoTerms().entrySet().stream()
@@ -1597,7 +1600,7 @@ public class AnnotateTabController {
 
     @FXML
     private void handleDragInTreeView(MouseEvent e) {
-        System.out.println("Drag event detected");
+        //System.out.println("Drag event detected");
         Dragboard db = treeView.startDragAndDrop(TransferMode.ANY);
         ClipboardContent content = new ClipboardContent();
         Object selectedItem = treeView.getSelectionModel().getSelectedItem().getValue();

--- a/loinc2hpogui/src/main/java/org/monarchinitiative/loinc2hpo/io/HpoOntologyParser.java
+++ b/loinc2hpogui/src/main/java/org/monarchinitiative/loinc2hpo/io/HpoOntologyParser.java
@@ -1,7 +1,5 @@
 package org.monarchinitiative.loinc2hpo.io;
 
-
-
 import com.google.common.collect.ImmutableMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -9,13 +7,11 @@ import org.monarchinitiative.phenol.base.PhenolException;
 import org.monarchinitiative.phenol.formats.hpo.HpoOntology;
 
 import org.monarchinitiative.phenol.io.obo.hpo.HpOboParser;
+import org.monarchinitiative.phenol.io.owl.hpo.HpOwlParser;
 import org.monarchinitiative.phenol.ontology.data.*;
+import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 
 import java.io.File;
-import java.io.IOException;
-import java.util.List;
-import java.util.stream.Collectors;
-
 
 /**
  * This class uses the <a href="https://github.com/phenomics/ontolib">ontolb</a> library to
@@ -24,16 +20,15 @@ import java.util.stream.Collectors;
  * (see <a href="http://human-phenotype-ontology.github.io/">HPO Homepage</a>).
  * @author Peter Robinson
  * @author Vida Ravanmehr
- * @version 0.1.1 (2017-11-15)
+ * @author Aaron Zhang
  */
 public class HpoOntologyParser {
     private static final Logger logger = LogManager.getLogger();
     /** Path to the {@code hp.obo} file. */
-    private String hpoOntologyPath=null;
-
-    private TermPrefix pref = new TermPrefix("HP");
-    private final TermId INHERITANCE = new TermId(pref,"0000005");
-    HpoOntology ontology;
+    private String hpoOboPath =null;
+    private String hpoOwlPath = null;
+    private boolean isObo = false;
+    private HpoOntology hpoOntology;
 
     /** Map of all of the Phenotypic abnormality terms (i.e., not the inheritance terms). */
     private ImmutableMap<String, Term> termmap;
@@ -41,43 +36,46 @@ public class HpoOntologyParser {
 
 
     public HpoOntologyParser(String path){
-
-        hpoOntologyPath=path;
-
-    }
-
-    /**
-     * Parse the HP ontology file and place the data in {@link #ontology} and
-     * @throws IOException
-     */
-    public void parseOntology() throws PhenolException {
-        HpOboParser hpoOboParser = new HpOboParser(new File(hpoOntologyPath));
-        logger.debug("ontology path: " + hpoOntologyPath);
-        this.ontology = hpoOboParser.parse();
-    }
-
-    private void initTermMaps() {
-        ImmutableMap.Builder<String,Term> termmapBuilder = new ImmutableMap.Builder<>();
-        ImmutableMap.Builder<TermId,Term> termmap2Builder = new ImmutableMap.Builder<>();
-        if (ontology !=null) {
-
-            // ontology.getTermMap().values().  forEach(term -> termmap.put(term.getName(), term));
-            // for some reason there is a bug here...issue #34 on ontolib tracker
-            // here is a workaround to remove duplicate entries
-            List<Term> res = ontology.getTermMap().values().stream().distinct()
-                    .collect(Collectors.toList());
-
-            res.forEach( term -> termmapBuilder.put(term.getName(),term));
-            termmap = termmapBuilder.build();
-            res.forEach( term -> termmap2Builder.put(term.getId(), term));
-            termmap2 = termmap2Builder.build();
-            //res.forEach( term -> logger.info(term.getName()));
+        if (path.contains(".obo")) {
+            isObo = true;
+            hpoOboPath = path;
+        } else {
+            hpoOwlPath = path;
         }
     }
 
-    public Ontology getPhenotypeSubontology() { return ontology.getPhenotypicAbnormalitySubOntology(); }
-    public Ontology getInheritanceSubontology() { return ontology.subOntology(INHERITANCE); }
-    public HpoOntology getOntology() { return ontology; }
+    /**
+     * Parse the HP ontology file and place the data in {@link #hpoOntology} and
+     * @throws PhenolException, OWLOntologyCreationException
+     */
+    public void parseOntology() throws PhenolException, OWLOntologyCreationException {
+        if (isObo) {
+            HpOboParser hpoOboParser = new HpOboParser(new File(hpoOboPath));
+            logger.debug("ontology path: " + hpoOboPath);
+            this.hpoOntology = hpoOboParser.parse();
+        } else {
+            HpOwlParser hpoOwlParser = new HpOwlParser(new File(hpoOwlPath));
+            this.hpoOntology = hpoOwlParser.parse();
+        }
+    }
+
+    private void initTermMaps() {
+        if (hpoOntology !=null) {
+            termmap2 = ImmutableMap.copyOf(this.hpoOntology.getTermMap());
+            ImmutableMap.Builder<String,Term> termmapBuilder = new ImmutableMap.Builder<>();
+            this.hpoOntology.getTerms().forEach(term -> termmapBuilder.put(term.getName(), term));
+            termmap = termmapBuilder.build();
+        }
+    }
+
+    //public Ontology getPhenotypeSubontology() { return ontology.getPhenotypicAbnormalitySubOntology(); }
+    //public Ontology getInheritanceSubontology() { return ontology.subOntology(INHERITANCE); }
+
+    public HpoOntology getOntology() {
+
+        return this.hpoOntology;
+
+    }
 
     /** @return a map will all terms of the Hpo Phenotype subontology. */
     public ImmutableMap<String,Term> getTermMap() {

--- a/loinc2hpogui/src/main/java/org/monarchinitiative/loinc2hpo/io/HpoOntologyParser.java
+++ b/loinc2hpogui/src/main/java/org/monarchinitiative/loinc2hpo/io/HpoOntologyParser.java
@@ -5,8 +5,10 @@ package org.monarchinitiative.loinc2hpo.io;
 import com.google.common.collect.ImmutableMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.monarchinitiative.phenol.base.PhenolException;
 import org.monarchinitiative.phenol.formats.hpo.HpoOntology;
-import org.monarchinitiative.phenol.io.obo.hpo.HpoOboParser;
+
+import org.monarchinitiative.phenol.io.obo.hpo.HpOboParser;
 import org.monarchinitiative.phenol.ontology.data.*;
 
 import java.io.File;
@@ -29,8 +31,8 @@ public class HpoOntologyParser {
     /** Path to the {@code hp.obo} file. */
     private String hpoOntologyPath=null;
 
-    private TermPrefix pref = new ImmutableTermPrefix("HP");
-    private final TermId INHERITANCE = new ImmutableTermId(pref,"0000005");
+    private TermPrefix pref = new TermPrefix("HP");
+    private final TermId INHERITANCE = new TermId(pref,"0000005");
     HpoOntology ontology;
 
     /** Map of all of the Phenotypic abnormality terms (i.e., not the inheritance terms). */
@@ -48,8 +50,8 @@ public class HpoOntologyParser {
      * Parse the HP ontology file and place the data in {@link #ontology} and
      * @throws IOException
      */
-    public void parseOntology() throws IOException {
-        HpoOboParser hpoOboParser = new HpoOboParser(new File(hpoOntologyPath));
+    public void parseOntology() throws PhenolException {
+        HpOboParser hpoOboParser = new HpOboParser(new File(hpoOntologyPath));
         logger.debug("ontology path: " + hpoOntologyPath);
         this.ontology = hpoOboParser.parse();
     }

--- a/loinc2hpogui/src/main/java/org/monarchinitiative/loinc2hpo/model/Model.java
+++ b/loinc2hpogui/src/main/java/org/monarchinitiative/loinc2hpo/model/Model.java
@@ -17,6 +17,7 @@ import java.util.*;
 import java.util.List;
 import java.util.stream.Collectors;
 import javafx.scene.paint.Color;
+import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 
 /**
  * Prototype model for LOINC to HPO Biocuration process.
@@ -336,12 +337,14 @@ public class Model {
             logger.error("Attempt to parse hp.obo file with null path to file");
             return;
         }
-        HpoOntologyParser parser = new HpoOntologyParser(pathToHpoOboFile);
+        HpoOntologyParser parser = new HpoOntologyParser(pathToHpoOwlFile);
         try {
             parser.parseOntology();
             this.ontology = parser.getOntology();
         } catch (PhenolException e) {
             logger.error("Could not parse HPO obo file at "+pathToHpoOboFile);
+        } catch (OWLOntologyCreationException e) {
+            logger.error("Could not parge HPO owl file at " + pathToHpoOwlFile);
         }
         termmap=parser.getTermMap();
         termmap2=parser.getTermMap2();

--- a/loinc2hpogui/src/main/java/org/monarchinitiative/loinc2hpo/model/Model.java
+++ b/loinc2hpogui/src/main/java/org/monarchinitiative/loinc2hpo/model/Model.java
@@ -8,6 +8,7 @@ import org.hl7.fhir.dstu3.model.Observation;
 import org.monarchinitiative.loinc2hpo.Constants;
 import org.monarchinitiative.loinc2hpo.io.HpoOntologyParser;
 import org.monarchinitiative.loinc2hpo.loinc.*;
+import org.monarchinitiative.phenol.base.PhenolException;
 import org.monarchinitiative.phenol.formats.hpo.HpoOntology;
 import org.monarchinitiative.phenol.ontology.data.*;
 
@@ -49,7 +50,7 @@ public class Model {
 
     /** The complete HPO ontology. */
     private HpoOntology ontology=null;
-    private static final TermPrefix HPPREFIX = new ImmutableTermPrefix("HP");
+    private static final TermPrefix HPPREFIX = new TermPrefix("HP");
     /** Key: a loinc code such as 10076-3; value: the corresponding TODO -- what link QnLoinc2HPOAnnotation object .*/
     public Map<LoincId,LOINC2HpoAnnotationImpl> loincAnnotationMap =new LinkedHashMap<>();
     private Map<String, Set<LoincId>> userCreatedLoincLists = new LinkedHashMap<>();
@@ -290,7 +291,7 @@ public class Model {
             return null;
         }
         hpoId= hpoId.substring(3);
-        return new ImmutableTermId(HPPREFIX,hpoId);
+        return new TermId(HPPREFIX,hpoId);
     }
 
 
@@ -339,7 +340,7 @@ public class Model {
         try {
             parser.parseOntology();
             this.ontology = parser.getOntology();
-        } catch (IOException e) {
+        } catch (PhenolException e) {
             logger.error("Could not parse HPO obo file at "+pathToHpoOboFile);
         }
         termmap=parser.getTermMap();

--- a/loinc2hpogui/src/test/java/org/monarchinitiative/loinc2hpo/io/HpoOntologyParserTest.java
+++ b/loinc2hpogui/src/test/java/org/monarchinitiative/loinc2hpo/io/HpoOntologyParserTest.java
@@ -1,0 +1,51 @@
+package org.monarchinitiative.loinc2hpo.io;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.monarchinitiative.phenol.formats.hpo.HpoOntology;
+
+import static org.junit.Assert.*;
+
+@Ignore
+public class HpoOntologyParserTest {
+    final String hpo_owl = "/Users/zhangx/git/human-phenotype-ontology/hp.owl";
+    final String hpo_owl_edit = "/Users/zhangx/git/human-phenotype-ontology/src/ontology/hp-edit.owl";
+    final String hpo_obo = "/Users/zhangx/git/human-phenotype-ontology/src/ontology/hp.obo";
+    @Test (expected = Test.None.class)
+    public void parseObo() throws Exception {
+        HpoOntologyParser hpoOntologyParser = new HpoOntologyParser(hpo_obo);
+        hpoOntologyParser.parseOntology();
+    }
+
+    @Test (expected = Test.None.class)
+    public void parseOwl() throws Exception {
+        HpoOntologyParser hpoOntologyParser = new HpoOntologyParser(hpo_owl);
+        hpoOntologyParser.parseOntology();
+    }
+
+    @Test (expected = Test.None.class)
+    public void parseOwlEdit() throws Exception {
+        HpoOntologyParser hpoOntologyParser = new HpoOntologyParser(hpo_owl_edit);
+        hpoOntologyParser.parseOntology();
+    }
+
+    @Test
+    public void getOntology() throws Exception {
+        HpoOntologyParser hpoOntologyParser = new HpoOntologyParser(hpo_owl_edit);
+        hpoOntologyParser.parseOntology();
+        HpoOntology hpoOntology = hpoOntologyParser.getOntology();
+        System.out.println(hpoOntology.getTerms().size());
+    }
+
+    @Test
+    public void getTermMap() throws Exception {
+        HpoOntologyParser hpoOntologyParser = new HpoOntologyParser(hpo_owl_edit);
+        hpoOntologyParser.parseOntology();
+        System.out.println(hpoOntologyParser.getTermMap().get("Hyperglycemia").getId());
+    }
+
+    @Test
+    public void getTermMap2() throws Exception {
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <log4j.version>2.9.1</log4j.version>
         <jdk.version>1.8</jdk.version>
         <ontolib.version>0.3</ontolib.version>
-        <phenol.version>1.0.0</phenol.version>
+        <phenol.version>1.2.1</phenol.version>
         <junit.version>4.12</junit.version>
         <guava.version>23.0</guava.version>
         <slf4j.version>1.7.25</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,10 @@
                     <groupId>org.jgrapht</groupId>
                     <artifactId>jgrapht-core</artifactId>
                 </exclusion>
-
+                <!--<exclusion>-->
+                    <!--<groupId>net.sourceforge.owlapi</groupId>-->
+                    <!--<artifactId>owlapi-distribution</artifactId>-->
+                <!--</exclusion>-->
             </exclusions>
         </dependency>
         <!--dependency>
@@ -185,6 +188,14 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <!-- https://mvnrepository.com/artifact/net.sourceforge.owlapi/owlapi-distribution -->
+        <!--<dependency>-->
+            <!--<groupId>net.sourceforge.owlapi</groupId>-->
+            <!--<artifactId>owlapi-distribution</artifactId>-->
+            <!--<version>5.1.4</version>-->
+        <!--</dependency>-->
+
 
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
We can avoid obo but we still have to use hp.owl. We cannot switch to hp-edit as it is in functional syntax. 